### PR TITLE
Remove manual download targets

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -99,62 +99,38 @@ p1_targets <- list(
   format = 'file'),
   
   ###### Download annual stats files ######
-  ### FAILS WITH SBTOOLS VERSION 1.1.18 (multipart session error)
-  # tar_target(p1_1951_2020_annual_stats_site_csv, {
-  #   # Depend on this dummy variable to initiate re-download of files
-  #   p0_sb_fetch_date
-  #   download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-  #                     sb_files_to_download = 'annual_stats_weibull_site.csv',
-  #                     dest_dir = "1_fetch/out/CONUS_1951_2020",
-  #                     sb_secret_exists = p0_sb_credentials_exist)
-  # },
-  # format = 'file'),
-  # 
-  # USE MANUALLY DOWNLOADED FILE FOR NOW
-  # https://www.sciencebase.gov/catalog/item/627974ccd34e8d45aa6e3c81
-  # 'annual_stats_weibull_site.csv'
-  tar_target(p1_1951_2020_annual_stats_site_csv,
-             '1_fetch/in/annual_stats_weibull_site.csv',
-             format = 'file'),
+  tar_target(p1_1951_2020_annual_stats_site_csv, {
+    # Depend on this dummy variable to initiate re-download of files
+    p0_sb_fetch_date
+    download_sb_files(sb_id = p0_sbitem_child_1951_2020,
+                      sb_files_to_download = 'annual_stats_weibull_site.csv',
+                      dest_dir = "1_fetch/out/CONUS_1951_2020",
+                      sb_secret_exists = p0_sb_credentials_exist)
+  },
+  format = 'file'),
   
-  ### FAILS WITH SBTOOLS VERSION 1.1.18 (multipart session error)
-  # tar_target(p1_1951_2020_annual_stats_jd_csv, {
-  #   # Depend on this dummy variable to initiate re-download of files
-  #   p0_sb_fetch_date
-  #   download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-  #                     sb_files_to_download = 'annual_stats_weibull_jd.csv',
-  #                     dest_dir = "1_fetch/out/CONUS_1951_2020",
-  #                     sb_secret_exists = p0_sb_credentials_exist)
-  # },
-  # format = 'file'),
-  # USE MANUALLY DOWNLOADED FILE FOR NOW
-  # https://www.sciencebase.gov/catalog/item/627974ccd34e8d45aa6e3c81
-  # 'annual_stats_weibull_jd.csv'
-  tar_target(p1_1951_2020_annual_stats_jd_csv,
-             '1_fetch/in/annual_stats_weibull_jd.csv',
-             format = 'file'),
+  tar_target(p1_1951_2020_annual_stats_jd_csv, {
+    # Depend on this dummy variable to initiate re-download of files
+    p0_sb_fetch_date
+    download_sb_files(sb_id = p0_sbitem_child_1951_2020,
+                      sb_files_to_download = 'annual_stats_weibull_jd.csv',
+                      dest_dir = "1_fetch/out/CONUS_1951_2020",
+                      sb_secret_exists = p0_sb_credentials_exist)
+  },
+  format = 'file'),
   
   ###### Download streamflow percentile files ######
   
-  ### Zip file isn't downloading correctly with sbtools::item_file_download()
-  ### I _think_ b/c its type is 'application/x-zip-compressed' instead of 'application/zip'
-  ### FAILS WITH SBTOOLS VERSION 1.1.17 (empty zip) and 1.1.18 (multipart session error)
-  # tar_target(p1_1951_2020_streamflow_perc_zip, {
-  #   # Depend on this dummy variable to initiate re-download of files
-  #   p0_sb_fetch_date
-  #   download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-  #                     sb_files_to_download = 'Streamflow_percentiles_national_1951.zip',
-  #                     dest_dir = "1_fetch/tmp",
-  #                     sb_secret_exists = p0_sb_credentials_exist)
-  # },
-  # format = 'file'),
-  # USE MANUALLY DOWNLOADED ZIP FOR NOW
-  # https://www.sciencebase.gov/catalog/item/627974ccd34e8d45aa6e3c81
-  # 'Streamflow_percentiles_national_1951.zip'
-  tar_target(p1_1951_2020_streamflow_perc_zip,
-             '1_fetch/in/Streamflow_percentiles_national_1951.zip',
-             format = 'file'),
-  
+  tar_target(p1_1951_2020_streamflow_perc_zip, {
+    # Depend on this dummy variable to initiate re-download of files
+    p0_sb_fetch_date
+    download_sb_files(sb_id = p0_sbitem_child_1951_2020,
+                      sb_files_to_download = 'Streamflow_percentiles_national_1951.zip',
+                      dest_dir = "1_fetch/tmp",
+                      sb_secret_exists = p0_sb_credentials_exist)
+  },
+  format = 'file'),
+
   tar_target(p1_1951_2020_streamflow_perc_csvs, {
     utils::unzip(zipfile = p1_1951_2020_streamflow_perc_zip,
                  exdir = "1_fetch/out/CONUS_1951_2020/streamflow_percentiles", junkpaths = TRUE)


### PR DESCRIPTION
The `sbtools` bug that prevented downloading files from SB Cloud is now fixed.

If you reinstall `sbtools` from Github, with `remotes::install_github("USGS-R/sbtools")`, so that you have `sbtools` version 1.1.19, then the full pipeline can be built w/o downloading any files manually.

Althea - to review, I think all that's needs to check if the pipeline builds with these changes and the updated `sbtools` on your machine