### PR TITLE
working pipeline to prep data for plotting viz learner

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -43,22 +43,13 @@ p1_targets <- list(
     # Depend on this dummy variable to initiate re-download of files
     p0_sb_fetch_date
     download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-                      sb_files_to_download = 'Drought_Summary_jd_30_wndw.csv',
+                      sb_files_to_download = 'Drought_Summary_jd_30d_wndw.csv',
                       dest_dir = "1_fetch/out/CONUS_1951_2020",
                       sb_secret_exists = p0_sb_credentials_exist)
   },
   format = 'file'),
   
-  ###### Download streamflow auditing file ######
-  tar_target(p1_1951_2020_streamflow_audit_csv, {
-    # Depend on this dummy variable to initiate re-download of files
-    p0_sb_fetch_date
-    download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-                      sb_files_to_download = 'streamflow_auditing_national_1951.csv',
-                      dest_dir = "1_fetch/out/CONUS_1951_2020",
-                      sb_secret_exists = p0_sb_credentials_exist)
-  },
-  format = 'file'),
+
   
   ###### Download drought properties files ######
   tar_target(p1_1951_2020_drought_prop_site_csv, {
@@ -83,7 +74,7 @@ p1_targets <- list(
     # Depend on this dummy variable to initiate re-download of files
     p0_sb_fetch_date
     download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-                      sb_files_to_download = 'Drought_Properties_jd_07_wndw_updated.csv',
+                      sb_files_to_download = 'Drought_Properties_jd_07d_wndw_updated.csv',
                       dest_dir = "1_fetch/out/CONUS_1951_2020",
                       sb_secret_exists = p0_sb_credentials_exist)
   },
@@ -92,7 +83,7 @@ p1_targets <- list(
     # Depend on this dummy variable to initiate re-download of files
     p0_sb_fetch_date
     download_sb_files(sb_id = p0_sbitem_child_1951_2020,
-                      sb_files_to_download = 'Drought_Properties_jd_30_wndw_updated.csv',
+                      sb_files_to_download = 'Drought_Properties_jd_30d_wndw_updated.csv',
                       dest_dir = "1_fetch/out/CONUS_1951_2020",
                       sb_secret_exists = p0_sb_credentials_exist)
   },

--- a/2_process.R
+++ b/2_process.R
@@ -55,14 +55,14 @@ p2_targets <- list(
   ###### Process data for the drought learner viz ######
   # The df that has the drought properties by method (variable vs fixed)
   tar_target(p2_droughts_learner_viz_df,
-             prep_drought_df_lrnr_viz(StaID = '03221000',
-                                      year = 1963,
+             prep_drought_df_lrnr_viz(StationID = '03221000',
+                                      focal_year = 1963,
                                       p2_1951_2020_drought_prop_site,
                                       p2_1951_2020_drought_prop_jd_7d)),
   # The df that has the streamflow values and thresholds by day
   tar_target(p2_streamflow_learner_viz_df,
-             prep_streamflow_df_lrnr_viz(StaID = '03221000',
-                                         year = 1963,
+             prep_streamflow_df_lrnr_viz(StationID = '03221000',
+                                         focal_year = 1963,
                                          p2_1951_2020_metadata,
                                          p2_1951_2020_streamflow_perc))
 )

--- a/2_process.R
+++ b/2_process.R
@@ -21,9 +21,6 @@ p2_targets <- list(
   tar_target(p2_1951_2020_drought_summary_jd_30d,
              readr::read_csv(p1_1951_2020_drought_summary_jd_30d_csv, col_types = cols())),
   
-  ###### Load streamflow auditing ######
-  tar_target(p2_1951_2020_streamflow_audit,
-             readr::read_csv(p1_1951_2020_streamflow_audit_csv, col_types = cols())),
   
   ###### Load drought properties ######
   tar_target(p2_1951_2020_drought_prop_site,

--- a/2_process.R
+++ b/2_process.R
@@ -1,4 +1,4 @@
-# source('2_process/src/')
+source('2_process/src/df_for_drought_learner_viz.R')
 
 p2_targets <- list(
   ##### General metadata #####
@@ -44,11 +44,25 @@ p2_targets <- list(
   ###### Load streamflow percentile data ######
   # Only load for subset of sites
   tar_target(p2_1951_2020_metadata_subset,
-             p2_1951_2020_metadata %>% slice(1:5)),
+             p2_1951_2020_metadata %>% filter(StaID %in% c("01436000", "03221000"))),
   tar_target(p2_1951_2020_streamflow_perc_file_tibble,
              p2_1951_2020_metadata_subset %>%
                select(StaID) %>%
                left_join(p1_1951_2020_streamflow_perc_csvs_tibble, by='StaID')),
   tar_target(p2_1951_2020_streamflow_perc,
-             purrr::map_df(p2_1951_2020_streamflow_perc_file_tibble$flow_perc_fl, ~readr::read_csv(.x, col_types=cols())))
+             purrr::map_df(p2_1951_2020_streamflow_perc_file_tibble$flow_perc_fl, ~readr::read_csv(.x, col_types=cols()))),
+  
+  ###### Process data for the drought learner viz ######
+  # The df that has the drought properties by method (variable vs fixed)
+  tar_target(p2_droughts_learner_viz_df,
+             prep_drought_df_lrnr_viz(StaID = '03221000',
+                                      year = 1963,
+                                      p2_1951_2020_drought_prop_site,
+                                      p2_1951_2020_drought_prop_jd_7d)),
+  # The df that has the streamflow values and thresholds by day
+  tar_target(p2_streamflow_learner_viz_df,
+             prep_streamflow_df_lrnr_viz(StaID = '03221000',
+                                         year = 1963,
+                                         p2_1951_2020_metadata,
+                                         p2_1951_2020_streamflow_perc))
 )

--- a/2_process/src/df_for_drought_learner_viz.R
+++ b/2_process/src/df_for_drought_learner_viz.R
@@ -1,0 +1,65 @@
+#' @description Function that combines the droughts as defined as "severe" (10%) for a give
+#' site and year and for the two methods: site-specific thresholds or variable thresholds defined
+#' by a 7 day floating window
+#' @param StaID char, Gage identifier 
+#' @param year num, year of interest
+#' @param p2_1951_2020_drought_prop_site df, the droughts as defined by the fixed, site-specific thresholds
+#' @param p2_1951_2020_drought_prop_jd_7d df, the droughts as defined by the variable thresholds with 
+#' a seven-day floating window (3 days on either side of a specific day)
+prep_drought_df_lrnr_viz <- function(StaID, year,
+                                     p2_1951_2020_drought_prop_site,
+                                     p2_1951_2020_drought_prop_jd_7d) {
+  
+  # Filter and simplify data to include only OH station and only 10% threshold and only 1963
+  p2_droughts_site <- p2_1951_2020_drought_prop_site %>%
+    filter(StaID == StaID, year(start) == year, threshold == 10) %>%
+    select(drought_id, duration, start, end, StaID, threshold) %>%
+    mutate("method" = "fixed")
+  p2_droughts_j7 <- p2_1951_2020_drought_prop_jd_7d %>%
+    filter(StaID == StaID, year(start) == year, threshold == 10) %>%
+    select(drought_id, duration, start, end, StaID, threshold) %>% 
+    mutate("method" = "variable")
+  
+  # Bind together
+  p2_droughts_learner_viz_df <- bind_rows(p2_droughts_site, p2_droughts_j7)
+  
+  return(p2_droughts_learner_viz_df)
+}
+
+#' @description Function that takes a focal year and site (StaID) and cleans and combines the
+#' streamflow percentiles and metadata to be ready for plotting in the drought learner viz
+#' @param StaID char, Gage identifier 
+#' @param year num, year of interest
+#' @param p2_1951_2020_metadata df, contains metadata about each station/gage, including 
+#' station name, etc
+#' @param p2_p2_1951_2020_streamflow_perc df, contains the streamflow values by year and 
+#' date for the stations, including also the thresholds used to define drought and the
+#' percentiles for each day's streamflow value based on the thresholds
+prep_streamflow_df_lrnr_viz <- function(StaID, year,
+                                        p2_1951_2020_metadata,
+                                        p2_1951_2020_streamflow_perc) {
+  
+  # First, only the focal site and year to create basic df
+  p2_streamflow <- p2_1951_2020_streamflow_perc %>% 
+    # by site and year
+    filter(StaID == StaID, year == year) %>%
+    select(dt, value, year, jd, thresh_10_site, thresh_10_jd_07d_wndw, StaID)
+  
+  # Second, calculate average streamflow by day of year
+  p2_streamflow_averages <- p2_1951_2020_streamflow_perc %>%
+    # By site and year
+    filter(StaID == StaID) %>%
+    # Summarize by day of year (julian day)
+    group_by(jd) %>%
+    summarise(mean_flow = mean(value))
+  
+  # Third extract station name from metadata
+  p2_streamflow <- p2_streamflow %>%
+    left_join(p2_1951_2020_metadata %>% select(StaID, STANAME, STATE), by = "StaID")
+  
+  # Finally add in the averages to the main df
+  p2_prep_streamflow_df_lrnr_viz <- p2_streamflow %>% 
+    left_join(p2_streamflow_averages, by = "jd")
+  
+  return(p2_prep_streamflow_df_lrnr_viz)
+}

--- a/2_process/src/df_for_drought_learner_viz.R
+++ b/2_process/src/df_for_drought_learner_viz.R
@@ -1,22 +1,22 @@
 #' @description Function that combines the droughts as defined as "severe" (10%) for a give
 #' site and year and for the two methods: site-specific thresholds or variable thresholds defined
 #' by a 7 day floating window
-#' @param StaID char, Gage identifier 
-#' @param year num, year of interest
+#' @param StationID char, Gage identifier 
+#' @param focal_year num, year of interest
 #' @param p2_1951_2020_drought_prop_site df, the droughts as defined by the fixed, site-specific thresholds
 #' @param p2_1951_2020_drought_prop_jd_7d df, the droughts as defined by the variable thresholds with 
 #' a seven-day floating window (3 days on either side of a specific day)
-prep_drought_df_lrnr_viz <- function(StaID, year,
+prep_drought_df_lrnr_viz <- function(StationID, focal_year,
                                      p2_1951_2020_drought_prop_site,
                                      p2_1951_2020_drought_prop_jd_7d) {
   
   # Filter and simplify data to include only OH station and only 10% threshold and only 1963
   p2_droughts_site <- p2_1951_2020_drought_prop_site %>%
-    filter(StaID == StaID, year(start) == year, threshold == 10) %>%
+    filter(StaID == StationID, year(start) == focal_year, threshold == 10) %>%
     select(drought_id, duration, start, end, StaID, threshold) %>%
     mutate("method" = "fixed")
   p2_droughts_j7 <- p2_1951_2020_drought_prop_jd_7d %>%
-    filter(StaID == StaID, year(start) == year, threshold == 10) %>%
+    filter(StaID == StationID, year(start) == focal_year, threshold == 10) %>%
     select(drought_id, duration, start, end, StaID, threshold) %>% 
     mutate("method" = "variable")
   
@@ -28,27 +28,27 @@ prep_drought_df_lrnr_viz <- function(StaID, year,
 
 #' @description Function that takes a focal year and site (StaID) and cleans and combines the
 #' streamflow percentiles and metadata to be ready for plotting in the drought learner viz
-#' @param StaID char, Gage identifier 
-#' @param year num, year of interest
+#' @param StationID char, Gage identifier 
+#' @param focal_year num, year of interest
 #' @param p2_1951_2020_metadata df, contains metadata about each station/gage, including 
 #' station name, etc
 #' @param p2_p2_1951_2020_streamflow_perc df, contains the streamflow values by year and 
 #' date for the stations, including also the thresholds used to define drought and the
 #' percentiles for each day's streamflow value based on the thresholds
-prep_streamflow_df_lrnr_viz <- function(StaID, year,
+prep_streamflow_df_lrnr_viz <- function(StationID, focal_year,
                                         p2_1951_2020_metadata,
                                         p2_1951_2020_streamflow_perc) {
   
   # First, only the focal site and year to create basic df
   p2_streamflow <- p2_1951_2020_streamflow_perc %>% 
     # by site and year
-    filter(StaID == StaID, year == year) %>%
+    filter(StaID == StationID, year == focal_year) %>%
     select(dt, value, year, jd, thresh_10_site, thresh_10_jd_07d_wndw, StaID)
   
   # Second, calculate average streamflow by day of year
   p2_streamflow_averages <- p2_1951_2020_streamflow_perc %>%
     # By site and year
-    filter(StaID == StaID) %>%
+    filter(StaID == StationID) %>%
     # Summarize by day of year (julian day)
     group_by(jd) %>%
     summarise(mean_flow = mean(value))

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -7,6 +7,7 @@ p3_targets <- list(
   #
   tar_target(p3_drought_learner_viz01_png,
              drought_lrnr_viz01(p2_droughts_learner_viz_df,
-                                p2_streamflow_learner_viz_df),
+                                p2_streamflow_learner_viz_df,
+                                out_png = "3_visualize/out/drought_learner_01.png"),
              format = "file")
 )

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,3 +1,12 @@
-# source('3_visualize/src/')
+source('3_visualize/src/drought_learner_viz.R')
 
-p3_targets <- list()
+p3_targets <- list(
+  #### Creates a series of ggplot pngs that will get pulled together downstream
+  #
+  # NOTE: Must make sure that target 'p2_1951_2020_metadata_subset' includes the correct data
+  #
+  tar_target(p3_drought_learner_viz01_png,
+             drought_lrnr_viz01(p2_droughts_learner_viz_df,
+                                p2_streamflow_learner_viz_df),
+             format = "file")
+)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -9,5 +9,18 @@ p3_targets <- list(
              drought_lrnr_viz01(p2_droughts_learner_viz_df,
                                 p2_streamflow_learner_viz_df,
                                 out_png = "3_visualize/out/drought_learner_01.png"),
-             format = "file")
+             format = "file"),
+  
+  tar_target(p3_drought_learner_viz02_png,
+             drought_lrnr_viz01(p2_droughts_learner_viz_df,
+                                p2_streamflow_learner_viz_df,
+                                out_png = "3_visualize/out/drought_learner_02.png"),
+             format = "file"),
+  
+  # Wrap up all the frames into a tibble that has filepaths 
+  # to each of the exported pngs for each frame, 
+  # and a variable with the numeric sequencing of the pngs
+  tar_target(p3_learner_viz_tibble,
+             tibble(filepaths = c(p3_drought_learner_viz01_png, p3_drought_learner_viz02_png),
+                    frame_number = 1:length(filepaths)))
 )

--- a/3_visualize/src/drought_learner_viz.R
+++ b/3_visualize/src/drought_learner_viz.R
@@ -1,0 +1,57 @@
+#' @title 
+#' @description 
+#' @param name 
+#' @param 
+drought_lrnr_viz01 <- function(p2_droughts_learner_viz_df, p2_streamflow_learner_viz_df) {
+  
+  # Login to SB first first. Need to do this for each task that calls
+  stopifnot(sb_secret_exists)
+  login_with_local_sb_credentials()
+  
+  # List all the files associated with `sb_id`
+  sb_files <- sbtools::item_list_files(sb_id)[["fname"]]
+  
+  # Find just the files that match the pattern passed in
+  sb_files_service <- sb_files[grepl(pattern, sb_files)]
+  
+  # Remove any that were noted in `exceptions`
+  if(!is.null(exceptions)) {
+    sb_files_keep <- sb_files_service[!grepl(paste(exceptions, collapse="|"), sb_files_service)]
+  } else {
+    sb_files_keep <- sb_files_service
+  }
+  
+  return(sb_files_keep)
+}
+
+#' @title Download files from ScienceBase
+#' @description Download specific ScienceBase files from one ScienceBase item to a local
+#' directory. Set up to retry at least 3 times if there is an error to handle network flakiness.
+#' @param sb_id character string of the ScienceBase item to inventory
+#' @param sb_files_to_download character vector of the filenames on ScienceBase. Designed to work
+#' with output from `inventory_sb_pcode_files()`.
+#' @param dest_dir character string of the local directory (which should exist already) to
+#' download the ScienceBase files to.
+#' @param sb_secret_exists logical indicating whether or not the user has local
+#' ScienceBase credentials stored for `login_with_local_sb_credentials()` to use.
+download_sb_files <- function(sb_id, sb_files_to_download, dest_dir, sb_secret_exists) {
+  
+  # Login to SB first first. Need to do this for each task that calls
+  stopifnot(sb_secret_exists)
+  login_with_local_sb_credentials()
+  
+  # Download the files and save in the local directory
+  files_local_name <- file.path(dest_dir, sb_files_to_download)
+  files_out <- retry(
+    sbtools::item_file_download(
+      sb_id,
+      names = sb_files_to_download,
+      destinations = files_local_name,
+      overwrite_file = TRUE),
+    when = "Error:",
+    max_tries = 3)
+  
+  # `item_file_download()` returns the local filepaths
+  # so pass these on to the user
+  return(files_out)
+}

--- a/_targets.R
+++ b/_targets.R
@@ -5,7 +5,9 @@ tar_option_set(packages = c("retry",
                             "secret",
                             "tidyverse",
                             "zip",
-                            'ggplot2'))
+                            'ggplot2',
+                            'lubridate',
+                            'scales'))
 
 # Phase target makefiles
 source("0_config.R")


### PR DESCRIPTION
This PR updates the pipeline to begin creating the individual png frames for the "drought learner viz." Essentially it creates two data frames for inputting, one with thresholds and streamflow values by date and one for the drought events. It then uses those input data frames to create the figures as pngs. The end result is a tibble that has file paths for the pngs and the frame number, which tells which order those files go in.

_Note: For this to run, the target `p0_sb_fetch_date` has to be rebuilt since those data tables have values that were not in Caelan's original data release. Updating these data took about 8 minutes on my computer._

For review: This pull request is mainly to make sure the pipeline is set up properly to begin. It makes this figure, which is a place holder for now. The next series of edits will be to duplicate target `p3_drought_learner_vizXX_png` for figures `XX = 01`, `XX = 02`, etc for the numerous frames that will eventually be wrapped up together to make a gif. The pngs themselves are not formatted for the draft gif yet. 


![drought_learner_01](https://user-images.githubusercontent.com/19958841/180296201-a0de6ad9-a9f5-4184-ac4d-357a690c09c6.png)

