### PR TITLE
Adjust layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -117,7 +117,7 @@ h2{
   font-family: $SourceSans;
   font-size: 3.75em;
   margin-top: 0px;
-  line-height: 1.2;
+  line-height: 1;
     //color: $textcolor;
   @media screen and (max-width: 600px) {
     font-size: 3em;

--- a/src/App.vue
+++ b/src/App.vue
@@ -112,7 +112,7 @@ h1{
   }
 }
 h2{
-  font-weight: 700;
+  font-weight: 200;
   text-align: left;
   font-family: $SourceSans;
   font-size: 3.75em;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1,20 +1,13 @@
 <template>
   <div class="another-container">
-    <div class="chart-container">
-      <div id="title-container">
-        <h2 class="knockout-text">
-          What is streamflow drought?
-        </h2>
-      </div>
-      <div class = 'chevronContainer'>
-        <div class = 'chevron'></div>
-        <div class = 'chevron'></div>
-        <div class = 'chevron'></div>
-      </div>
-    </div>
     
     <div class="grid-container">
-      
+      <h2 class="title-text">
+        What is <span class='emph'>streamflow</span> drought?
+      </h2>
+      <div class = 'chevron'></div>
+      <div class = 'chevron'></div>
+      <div class = 'chevron'></div>
       <div id="hydro-chart-container">
         <svg class="hydro-chart" id="svg" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 240 240">
           <defs>
@@ -696,16 +689,16 @@
       <!-- create a scrolling div for each frame -->
 
 
-      <div id="textbox-container">
-        <p
-          v-for="frame in frames" 
-          :key="frame.id"
-          :id="`step-${frame.id}`"
-          class="textBox hidden"
-        >
-          {{ frame.text }}
-        </p>
-      </div>
+      <!--div id="textbox-container"-->
+      <p
+        v-for="frame in frames" 
+        :key="frame.id"
+        :id="`step-${frame.id}`"
+        class="textBox hidden"
+      >
+        {{ frame.text }}
+      </p>
+      <!--/div-->
       
     
       
@@ -759,13 +752,13 @@ export default {
 
       // things that go before containers
             // use class to set trigger
-         tl.to('.knockout-text', {
+         tl.to('.title-text', {
           scrollTrigger: {  
             markers: false,
-            trigger: '.knockout-text',
+            trigger: '.title-text',
             start: "top center",
             end: "top 10%",
-            toggleClass: {targets: `.knockout-text`, className:"bigger"}, // adds class to target when triggered
+            toggleClass: {targets: `.title-text`, className:"bigger"}, // adds class to target when triggered
             toggleActions: "restart none none none" // onEnter onLeave ... ...
             /*
             onEnter - scrolling down, start meets scroller-start
@@ -827,143 +820,111 @@ export default {
 $writeFont: 'Nanum Pen Script', cursive;
 $base: 0.6rem; //for chevron scroll animation
 // frames are stacked and class is added on an off w/ scroll trigger to bring to front
+$usgsBlue: #032a56;
 
-
-#title-container {
-  position: fixed;
-  background-size: cover;
+.grid-container{
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 0.5fr 1fr 3fr;
+  grid-template-areas:
+    "title chevron"
+    "textbox textbox"
+    "chart chart";
+  justify-content: center;
+  margin: auto;
+  width:100%;
+  position: sticky;
+  left: 10px;
+  top: 81px;
+  @media (min-width: 900px){
+    width: 70vw;
+    max-width: 1400px;
+    grid-template-columns: minmax(100px, 400px) auto 1fr;
+    grid-template-rows: 1fr 3fr;
+    grid-template-areas:
+      "title title chevron"
+      "textbox chart chart"
+  }
 }
-.knockout-text {
-  font-size: 2.5em;
-  font-weight: bold;
-  font-family: Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: #032a56;
-  padding: 0 0 0 50px;
+.title-text {
+  grid-area: title;
+  align-self: center;
+  font-size: 2em;
+  padding: 0 0 0 0;
+  color: $usgsBlue;
   @media (min-width: 900px){
     font-size:3.0em;
   }
 }
 .bigger {
-  font-size: 15vh;
-}
-
-.grid-container{
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 0.5fr;
-  grid-template-areas:
-    "textbox"
-    "chart";
-  grid-gap: 0;
-  align-content: start;
-  width:100%;
-  height: 80vh;
-  position: sticky;
-  left: 10px;
-  top: 35vh;
+  padding: 40vh 0 40vh 0;
   @media (min-width: 900px){
-    grid-template-columns: 1fr 3fr;
-    grid-template-areas:
-      "textbox chart"
+    margin-left: 40px;
+    margin-bottom: 60px;
   }
 }
-
 #hydro-chart-container{
   font-size: 1.2rem;
   grid-area: chart; // names the grid child component
-  place-self: center;
+  align-self: start;
+  justify-self: center;
+  height: 60vh;
   display: flex;
     display: -webkit-flex;
     justify-content: space-between;
     -webkit-justify-content: space-between;
 }
-
-
-
-#textbox-container{
-  grid-area: textbox; // names the grid child component
-}
-.text-container {
-  border-radius: 25px;
-  background: #FFE3AD;
-  position:absolute;
-  p{
-    padding: 15px;
+.textBox {
+  grid-area: textbox;
+  align-self: center;
+  justify-self: center;
+  color: $usgsBlue;
+  position: absolute;
+  padding: 0 0 0 0;
+  @media (min-width: 900px){
+    align-self: center;
+    justify-self: end;
   }
-  @media (min-width:900px) {
-    max-width:25%;
-  }
-}
-
-#scroll-container {
-  padding: 5rem 1rem;
-}
-
-
-
-.scrolly{
-  height:60vh;
-}
-
-
-
-.hydro-chart {
-  position:sticky;
-  padding:0;
-  margin:0;
-  width: 80vw;
-  max-height: 60vh;
-  height: auto;
-  /*aspect-ratio: 1/1;*/
-  @media (min-width: 900px) {
-    width: 65vw;
-    max-height: 65vh;
-  }
-}
-
-.chart-container {
-  //background-position: top;
-  height: 85vh;
-  max-height: 700px;
-  width: 50vw;
-  position: relative;
-  top:10vh;
-  left: 0vh;
-  margin-bottom: 5%;
-  max-width: 800px;
 }
 // currently empty scroll-by divs used to trigger animation
-.scrolly {
-  p {
-    color: black;
-  }
+.scrolly{
+  height:100vh;
+}
+.hydro-chart {
+  padding:0;
+  margin:0;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
 }
 
 #spacer {
   height: 30vh;
 }
 
-.chevronContainer {
-  position: fixed;
-  display: flex;
-  justify-contents: center;
-  align-items: center;
-  width: 100%;
-  height: 10vh;
-}
 .chevron {
+  grid-area: chevron;
+  align-self: center;
+  justify-self: start;
   position: absolute;
+  margin-left: 20px;
+  margin-bottom: 80px;
   width: $base * 3.5;
   height: $base * 0.8;
   opacity: 0;
   transform: scale(0.3);
-  animation: move-chevron 3s ease-out infinite;
-}
-.chevron:first-child {
   animation: move-chevron 3s ease-out 1s infinite;
+  @media (min-width: 900px){
+    margin-left: 40px;
+    margin-bottom: 60px;
+  }
 }
 .chevron:nth-child(2) {
   animation: move-chevron 3s ease-out 2s infinite;
+}
+.chevron:nth-child(3) {
+  animation: move-chevron 3s ease-out infinite;
 }
 .chevron:before,
 .chevron:after {
@@ -1106,5 +1067,8 @@ $base: 0.6rem; //for chevron scroll animation
 
 .visible{
   visibility: visible;
+}
+.emph {
+  font-weight: 700;
 }
 </style>

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -878,7 +878,7 @@ $usgsBlue: #032a56;
 }
 // currently empty scroll-by divs used to trigger animation
 .scrolly{
-  height:100vh;
+  height:50vh;
 }
 .hydro-chart {
   padding:0;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -686,10 +686,6 @@
           
         </svg>
       </div>
-      <!-- create a scrolling div for each frame -->
-
-
-      <!--div id="textbox-container"-->
       <p
         v-for="frame in frames" 
         :key="frame.id"
@@ -698,12 +694,8 @@
       >
         {{ frame.text }}
       </p>
-      <!--/div-->
-      
-    
-      
     </div>
-
+    <!-- create a scrolling div for each frame -->
     <div id="scroll-container">
         <div
           v-for="frame in frames" 

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -817,14 +817,14 @@ $usgsBlue: #032a56;
 .grid-container{
   display: grid;
   grid-template-columns: 3fr 0.5fr;
-  grid-template-rows: 1fr 2.5fr auto;
+  grid-template-rows: 6em 10em auto;
   grid-template-areas:
     "title chevron"
     "textbox textbox"
     "chart chart";
   justify-content: center;
   margin: auto;
-  width:100%;
+  width:95vw;
   position: sticky;
   left: 10px;
   top: 81px;
@@ -850,7 +850,7 @@ $usgsBlue: #032a56;
   }
   transition: ease 1s;
   &--scrolled {
-    padding: 0 0 0 0;
+    padding: 5px 0 5px 0;
   }
 }
 #hydro-chart-container{
@@ -858,11 +858,15 @@ $usgsBlue: #032a56;
   grid-area: chart; // names the grid child component
   align-self: center;
   justify-self: center;
-  height: 60vh;
+  height: 95%;
+  max-height: 60vh;
   display: flex;
     display: -webkit-flex;
     justify-content: space-between;
     -webkit-justify-content: space-between;
+  @media (min-width: 950px){
+    height: 60vh;
+  }
 }
 .textBox {
   grid-area: textbox;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -9,7 +9,7 @@
       <div class = 'chevron'></div>
       <div class = 'chevron'></div>
       <div id="hydro-chart-container">
-        <svg class="hydro-chart" id="svg" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 240 240">
+        <svg class="hydro-chart" id="svg" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 240 240" preserveAspectRatio="xMidYMid meet">
           <defs>
             <clipPath id="clippath">
               <ellipse cx="120" cy="120" rx="119" ry="116.37" fill="none"/>
@@ -859,6 +859,7 @@ $usgsBlue: #032a56;
   align-self: center;
   justify-self: center;
   height: 95%;
+  width: 95%;
   max-height: 60vh;
   display: flex;
     display: -webkit-flex;
@@ -882,7 +883,7 @@ $usgsBlue: #032a56;
 }
 // currently empty scroll-by divs used to trigger animation
 .scrolly{
-  height:50vh;
+  height:60vh;
 }
 .hydro-chart {
   padding:0;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -817,7 +817,7 @@ $usgsBlue: #032a56;
 .grid-container{
   display: grid;
   grid-template-columns: 3fr 0.5fr;
-  grid-template-rows: 6em 10em auto;
+  grid-template-rows: auto 10em auto;
   grid-template-areas:
     "title chevron"
     "textbox textbox"

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -697,16 +697,14 @@
 
 
       <div id="textbox-container">
-        <div
+        <p
           v-for="frame in frames" 
           :key="frame.id"
           :id="`step-${frame.id}`"
-          class="hidden"
+          class="textBox hidden"
         >
-          <div class="text-container">
-            <p>{{ frame.text }}</p>
-          </div>
-        </div>
+          {{ frame.text }}
+        </p>
       </div>
       
     

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -744,14 +744,14 @@ export default {
 
       // things that go before containers
             // use class to set trigger
-         tl.to('.title-text', {
+         tl.to('.scroll-step-aa01', {
           scrollTrigger: {  
             markers: false,
-            trigger: '.title-text',
-            start: "top center",
-            end: "top 10%",
-            toggleClass: {targets: `.title-text`, className:"bigger"}, // adds class to target when triggered
-            toggleActions: "restart none none none" // onEnter onLeave ... ...
+            trigger: '.scroll-step-aa01',
+            start: "top 70%",
+            end: 99999,
+            toggleClass: {targets: `.title-text`, className:"title-text--scrolled"}, // adds class to target when triggered
+            toggleActions: "restart none none none" // onEnter onLeave ... ... restart none none none
             /*
             onEnter - scrolling down, start meets scroller-start
             onLeave - scrolling down, end meets scroller-end
@@ -780,8 +780,8 @@ export default {
           scrollTrigger: {
             markers: this.marker_on,
             trigger: `.${scrollClass}`,
-            start: "top 80%",
-            end: "bottom 80%",
+            start: "top 70%",
+            end: "bottom 70%",
             toggleClass: {targets: `#step-${scrollID}`, className:"visible"}, // adds class to target when triggered
             toggleActions: "restart reverse none reverse" 
             /*
@@ -816,8 +816,8 @@ $usgsBlue: #032a56;
 
 .grid-container{
   display: grid;
-  grid-template-columns: auto 1fr;
-  grid-template-rows: 0.5fr 1fr 3fr;
+  grid-template-columns: 3fr 0.5fr;
+  grid-template-rows: 1fr 2.5fr auto;
   grid-template-areas:
     "title chevron"
     "textbox textbox"
@@ -828,11 +828,12 @@ $usgsBlue: #032a56;
   position: sticky;
   left: 10px;
   top: 81px;
-  @media (min-width: 900px){
+  height: 88vh;
+  @media (min-width: 950px){
     width: 70vw;
     max-width: 1400px;
     grid-template-columns: minmax(100px, 400px) auto 1fr;
-    grid-template-rows: 1fr 3fr;
+    grid-template-rows: 0.5fr 3fr;
     grid-template-areas:
       "title title chevron"
       "textbox chart chart"
@@ -842,23 +843,20 @@ $usgsBlue: #032a56;
   grid-area: title;
   align-self: center;
   font-size: 2em;
-  padding: 0 0 0 0;
+  padding: 40vh 0 40vh 0;
   color: $usgsBlue;
-  @media (min-width: 900px){
+  @media (min-width: 950px){
     font-size:3.0em;
   }
-}
-.bigger {
-  padding: 40vh 0 40vh 0;
-  @media (min-width: 900px){
-    margin-left: 40px;
-    margin-bottom: 60px;
+  transition: ease 1s;
+  &--scrolled {
+    padding: 0 0 0 0;
   }
 }
 #hydro-chart-container{
   font-size: 1.2rem;
   grid-area: chart; // names the grid child component
-  align-self: start;
+  align-self: center;
   justify-self: center;
   height: 60vh;
   display: flex;
@@ -873,7 +871,7 @@ $usgsBlue: #032a56;
   color: $usgsBlue;
   position: absolute;
   padding: 0 0 0 0;
-  @media (min-width: 900px){
+  @media (min-width: 950px){
     align-self: center;
     justify-self: end;
   }
@@ -900,14 +898,14 @@ $usgsBlue: #032a56;
   align-self: center;
   justify-self: start;
   position: absolute;
-  margin-left: 20px;
+  margin-left: 10px;
   margin-bottom: 80px;
   width: $base * 3.5;
   height: $base * 0.8;
   opacity: 0;
   transform: scale(0.3);
   animation: move-chevron 3s ease-out 1s infinite;
-  @media (min-width: 900px){
+  @media (min-width: 950px){
     margin-left: 40px;
     margin-bottom: 60px;
   }


### PR DESCRIPTION
This PR adjusts the grid layout for the page and brings the title and chevron into the grid layout. I simplified the html structure (mostly dropping containing divs) in order to simplify placing items in the grid. On page load, the title has large top and bottom padding, but then when the first step div scrolls into view it transitions to regular padding. It's still not perfect, but hopefully an improvement. We can adjust as needed once the final content is in.

On page load, it looks like:

![image](https://user-images.githubusercontent.com/54007288/199307710-4db0c9e6-8692-4b74-8634-07d30e695ee5.png)

then once you scroll it shifts to:
![image](https://user-images.githubusercontent.com/54007288/199307793-ca1e91e6-2e82-4a71-9800-13ff3e61b749.png)
 or on mobile: 
![image](https://user-images.githubusercontent.com/54007288/199308041-8ca1c7c7-5aeb-4571-84b1-45ce5c8d210a.png)


To run, pull changes to your local machine and run `npm run serve` in your development IDE.

If you could test on Safari, that would be great. I've tested this on Edge, Firefox, and Chrome.