### PR TITLE
Drought team updates

### DIFF
--- a/src/assets/text/scrollyText.js
+++ b/src/assets/text/scrollyText.js
@@ -42,11 +42,11 @@ export default {
         },
         {
           id: 'd',
-          text: 'When considering records across the whole year, streamflow levels that fall below a threshold of 45 cfs are in the lowest 10%. This fixed threshold of 45 cfs is constant from day-to-day and identifies these drought events during the dry season when the lowest streamflow levels typically occur.'
+          text: 'When considering records across the whole year, streamflow levels that fall below a threshold of 45 cfs are in the lowest 10%. This fixed threshold of 45 cfs is constant from day-to-day and identifies these streamflow drought events during the dry season when the lowest streamflow levels typically occur.'
         },
         {
           id: 'e',
-          text: 'Using a 10% fixed threshold identifies two drought events for 1963 in the dry season. Unusually low flow at this time of year can reduce hydropower production, impair water quality, and require reservoir releases to provide water to communities.'
+          text: 'Using a 10% fixed threshold identifies two streamflow drought events for 1963 in the dry season. Unusually low flow at this time of year can reduce hydropower production, impair water quality, and require reservoir releases to provide water to communities.'
         },
         {
           id: 'f',
@@ -58,11 +58,11 @@ export default {
         },
         {
           id: 'h',
-          text: 'To identify drought events during wetter times of the year, a variable threshold can be used to compare streamflow to typical conditions at that time of the year. Here, streamflow drought occurs if streamflow falls below the lowest 10% of observations ever recorded for that particular day. The result is a threshold that varies from day to day.'
+          text: 'To identify streamflow drought events during wetter times of the year, a variable threshold can be used to compare streamflow to typical conditions at that time of the year. Here, streamflow drought occurs if streamflow falls below the lowest 10% of observations ever recorded for that particular day. The result is a threshold that varies from day to day.'
         },
         {
           id: 'i',
-          text: 'The variable threshold detects several drought events in the spring during the wet season. Low stream levels in the spring can reduce inflow to water supply reservoirs, affect the behavior and survival of aquatic species, and impact early season crops. This method also detects the drought in August, when streamflow was unusually low for even the dry season.'
+          text: 'The variable threshold detects several streamflow drought events in the spring during the wet season. Low stream levels in the spring can reduce inflow to water supply reservoirs, affect the behavior and survival of aquatic species, and impact early season crops. This method also detects the drought in August, when streamflow was unusually low for even the dry season.'
         },
         {
           id: 'j',

--- a/src/assets/text/scrollyText.js
+++ b/src/assets/text/scrollyText.js
@@ -46,7 +46,7 @@ export default {
         },
         {
           id: 'e',
-          text: 'Using a 10% fixed threshold identifies two streamflow drought events for 1963 in the dry season. Unusually low flow at this time of year can reduce hydropower production, impair water quality, and require reservoir releases to provide water to communities.'
+          text: 'Using a 10% fixed threshold identifies two streamflow drought events for 1963 in the dry season. Unusually low flow at this time of year can reduce hydropower production, impair water quality, and require reservoir releases to provide water to communities. Notice that even if streamflow goes over the threshold for a brief time (up to about 5 days), this is still one drought event'
         },
         {
           id: 'f',

--- a/src/assets/text/scrollyText.js
+++ b/src/assets/text/scrollyText.js
@@ -12,7 +12,7 @@ export default {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
           id: 'aa02',
-          text: 'When there is less rain or snowfall than typical, this can cause a meteorological drought.'
+          text: 'When there is less rain or snowfall than typical, this can be known as meteorological drought.'
         },
         {
           // id is used to source image files with the same naming

--- a/src/assets/text/scrollyText.js
+++ b/src/assets/text/scrollyText.js
@@ -6,25 +6,25 @@ export default {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
           id: 'aa01',
-          text: 'Drought is increasing for regions worldwide, threatening our water supplies and affecting our daily lives. What starts with reduced rain and snowfall can progress to impacts on soil moisture and streamflow.'
+          text: 'Drought is increasing for regions worldwide, threatening our water security and affecting our daily lives. What starts with reduced rain and snowfall can progress to impacts on soil moisture and streamflow.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
           id: 'aa02',
-          text: 'When there is less rain or snowfall than typical, this can be known as meteorological drought.'
+          text: 'When there is less rain or snowfall than typical, this is known as meteorological drought.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
           id: 'aa03',
-          text: 'If meteorological drought continues, soil moisture becomes depleted and agricultural drought sets in. To keep crops and livestock healthy, farmers might use more water for irrigation.'
+          text: 'If meteorological drought continues, soil moisture becomes depleted and agricultural drought sets in. To keep crops and livestock healthy, farmers might use more water for irrigation. Extensive irrigation can impair water supplies and quality for local communities.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
           id: 'aa04',
-          text: 'As these conditions persist, less water moves into and through streams. When streamflow levels are unusually low, this is defined as streamflow drought. But what does "unusually low" really mean?'
+          text: 'As these conditions persist, less water moves into and through streams. Reduced streamflow has significant impact on plants, animals, and humans. When streamflow levels are unusually low, this is defined as streamflow drought. But what does "unusually low" really mean?'
         },
         {
           // id is used to source image files with the same naming

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1292,6 +1292,16 @@
             <use xlink:href="#shadeMask-d"/>
             <use xlink:href="#healthy_sunflower"/>
             <use xlink:href="#woodcut_texture"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 24 55)">Normal</text>
+              <text transform="matrix(1 0 0 1 20.5 62)">conditions</text>
+              <text transform="matrix(1 0 0 1 70 55)">Meteorological</text>
+              <text transform="matrix(1 0 0 1 81 62)">drought</text>
+              <text transform="matrix(1 0 0 1 130 55)">Agricultural</text>
+              <text transform="matrix(1 0 0 1 136 62)">drought</text>
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
             
           <g class="hidden" id="step-aa02">
@@ -1313,6 +1323,16 @@
             <use xlink:href="#shadeMask-d"/>
             <use xlink:href="#healthy_sunflower"/>
             <use xlink:href="#woodcut_texture"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 24 55)">Normal</text>
+              <text transform="matrix(1 0 0 1 20.5 62)">conditions</text>
+              <text transform="matrix(1 0 0 1 70 55)">Meteorological</text>
+              <text transform="matrix(1 0 0 1 81 62)">drought</text>
+              <text transform="matrix(1 0 0 1 130 55)">Agricultural</text>
+              <text transform="matrix(1 0 0 1 136 62)">drought</text>
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
 
           <g class="hidden" id="step-aa03">
@@ -1334,6 +1354,16 @@
             <use xlink:href="#shadeMask-d"/>
             <use xlink:href="#sad_sunflower"/>
             <use xlink:href="#woodcut_texture"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 24 55)">Normal</text>
+              <text transform="matrix(1 0 0 1 20.5 62)">conditions</text>
+              <text transform="matrix(1 0 0 1 70 55)">Meteorological</text>
+              <text transform="matrix(1 0 0 1 81 62)">drought</text>
+              <text transform="matrix(1 0 0 1 130 55)">Agricultural</text>
+              <text transform="matrix(1 0 0 1 136 62)">drought</text>
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
 
           <g class="hidden" id="step-aa04">
@@ -1354,6 +1384,16 @@
             <use xlink:href="#dead_sunflower"/>
             <path id="dryRiver" class="riverBlue" d="M99.4,237.5c-.4-3-.9-6-1.6-9.2-4.6-21.2-3.2-27.5-14.6-48.6-16.5-30.6-2.5-40.2-2.5-40.2l-5.8,.4s-5.4,3.1-6.2,18.9,17.5,34.6,12.9,71.7c-.2,2-.7,4.4-1.2,6.9,6.5-.3,13-.5,19,.2Z"/>
             <use xlink:href="#woodcut_texture"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 24 55)">Normal</text>
+              <text transform="matrix(1 0 0 1 20.5 62)">conditions</text>
+              <text transform="matrix(1 0 0 1 70 55)">Meteorological</text>
+              <text transform="matrix(1 0 0 1 81 62)">drought</text>
+              <text transform="matrix(1 0 0 1 130 55)">Agricultural</text>
+              <text transform="matrix(1 0 0 1 136 62)">drought</text>
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
 
           <g class="hidden" id="step-a">
@@ -1368,6 +1408,10 @@
             <text transform="matrix(1 0 0 1 56.64 68.87)" class="streamtext">streamflow</text>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-b">
             <use xlink:href="#axis"/>
@@ -1404,6 +1448,10 @@
               <use xlink:href="#inset_d"/>
               <use xlink:href="#focalCircle-d"/>
             </g>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-c">
             <use xlink:href="#axis"/>
@@ -1413,6 +1461,10 @@
             <text transform="matrix(1 0 0 1 56.64 68.87)" class="streamtext">streamflow</text>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-d">
             <use xlink:href="#axis"/>
@@ -1424,6 +1476,10 @@
             <text transform="matrix(1 0 0 1 56.64 68.87)" class="streamtext">streamflow</text>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-e">
             <use xlink:href="#axis"/>
@@ -1441,6 +1497,10 @@
           <text transform="matrix(1 0 0 1 56.64 68.87)" class="streamtext">streamflow</text>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-f">
             <use xlink:href="#axis"/>
@@ -1459,6 +1519,10 @@
             </g>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-g">
             <use xlink:href="#axis"/>
@@ -1487,6 +1551,10 @@
             </g>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-h">
             <use xlink:href="#axis"/>
@@ -1505,6 +1573,10 @@
             </g>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-i">
             <use xlink:href="#axis"/>
@@ -1527,6 +1599,10 @@
             </g>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           <g class="hidden" id="step-j">
             <use xlink:href="#axis"/>
@@ -1571,6 +1647,10 @@
             </g>
             <use xlink:href="#inset_d"/>
             <use xlink:href="#focalCircle-d"/>
+            <g class="streamtext">
+              <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
+              <text transform="matrix(1 0 0 1 194 62)">drought</text>
+            </g>
           </g>
           
         </svg>

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1655,6 +1655,12 @@
               <text transform="matrix(1 0 0 1 188 55)">Streamflow</text>
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
+            <g class="threshtext">
+              <text transform="matrix(1 0 0 1 108 55)">Fixed threshold</text>
+              <text transform="matrix(1 0 0 1 124 62)">droughts</text>
+              <text transform="matrix(1 0 0 1 100.5 175)">Variable threshold</text>
+              <text transform="matrix(1 0 0 1 124 182)">droughts</text>
+            </g>
           </g>
           
         </svg>

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1270,6 +1270,10 @@
                   <text transform="matrix(1 0 0 1 206.1328 233.3403)">Oct</text>
                 </g>
               </g>
+            <linearGradient id="droughtGradient" gradientTransform="rotate(90)">
+              <stop offset="25%" stop-color="#ffffff" />
+              <stop offset="100%" stop-color="#D3BF95" />
+            </linearGradient>
           </defs>
 
           <g class="hidden" id="step-aa01">
@@ -1400,7 +1404,7 @@
             <use xlink:href="#axis"/>
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
-              <rect x="149.4" y="34.3" class="fade" width="17" height="172.8"/>
+              <rect x="149.4" y="34.3" fill="url(#droughtGradient)" width="17" height="172.8"/>
             </g>
             <use xlink:href="#daily streamflow mask"/>
             <use xlink:href="#daily streamflow"/>
@@ -1417,7 +1421,7 @@
             <use xlink:href="#axis"/>
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
-              <rect x="149.4" y="34.3" class="fade" width="17" height="172.8"/>
+              <rect x="149.4" y="34.3" fill="url(#droughtGradient)" width="17" height="172.8"/>
             </g>
             <use xlink:href="#fixed threshold"/>
             <use xlink:href="#daily streamflow mask"/>
@@ -1486,8 +1490,8 @@
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
               <rect x="178.1" y="216.6" width="39.2" height="7.1"/>
-              <rect x="149.4" y="34.3" class="fade" width="17" height="172.8"/>
-              <rect x="178.1" y="34.3" class="fade" width="39.2" height="172.8"/>
+              <rect x="149.4" y="34.3" fill="url(#droughtGradient)" width="17" height="172.8"/>
+              <rect x="178.1" y="34.3" fill="url(#droughtGradient)" width="39.2" height="172.8"/>
             </g>
             <use xlink:href="#fixed threshold"/>
             <text transform="matrix(1 0 0 1 31.81 198.53)" class="threshtext">Drought threshold</text>
@@ -1585,10 +1589,10 @@
               <rect x="39.7" y="216.6" width="5.2" height="7.1"/>
               <rect x="73.6" y="216.6" width="9.2" height="7.1"/>
               <rect x="149.4" y="216.6"  width="15.7" height="7.1"/>
-              <rect x="17.4" y="34.3" class="fade" width="11.8" height="172.8"/>
-              <rect x="39.7" y="34.3" class="fade" width="5.2" height="172.8"/>
-              <rect x="73.6" y="34.3" class="fade" width="9.2" height="172.8"/>
-              <rect x="149.4" y="34.3" class="fade" width="15.7" height="172.8"/>
+              <rect x="17.4" y="34.3" fill="url(#droughtGradient)" width="11.8" height="172.8"/>
+              <rect x="39.7" y="34.3" fill="url(#droughtGradient)" width="5.2" height="172.8"/>
+              <rect x="73.6" y="34.3" fill="url(#droughtGradient)" width="9.2" height="172.8"/>
+              <rect x="149.4" y="34.3" fill="url(#droughtGradient)" width="15.7" height="172.8"/>
             </g>
             <use xlink:href="#variable threshold"/>
             <g>
@@ -1613,10 +1617,10 @@
               <rect x="39.7" y="216.7" width="5.2" height="7"/>
               <rect x="73.6" y="216.7" width="9.2" height="7"/>
               <rect x="149.4" y="216.7" width="15.7" height="7"/>
-              <rect x="17.4" y="126.8" class="fade" width="11.8" height="84.3"/>
-              <rect x="39.7" y="126.8" class="fade" width="5.2" height="84.3"/>
-              <rect x="73.6" y="126.8" class="fade" width="9.2" height="84.3"/>
-              <rect x="149.4" y="126.8" class="fade" width="15.7" height="84.3"/>
+              <rect x="17.4" y="126.8" fill="url(#droughtGradient)" width="11.8" height="84.3"/>
+              <rect x="39.7" y="126.8" fill="url(#droughtGradient)" width="5.2" height="84.3"/>
+              <rect x="73.6" y="126.8" fill="url(#droughtGradient)" width="9.2" height="84.3"/>
+              <rect x="149.4" y="126.8" fill="url(#droughtGradient)" width="15.7" height="84.3"/>
             </g>
             <g id="daily_streamflow">
               <use xlink:href="#stacked streamflow bottom mask"/>
@@ -1636,8 +1640,8 @@
             <g id="fixed droughts" class="drought">
               <rect x="149.4" y="105.7" width="17" height="7"/>
               <rect x="178.1" y="105.7" width="39.2" height="7"/>
-              <rect x="149.4" y="19.8" class="fade" width="17" height="80.3"/>
-              <rect x="178.1" y="19.8" class="fade" width="39.2" height="80.3"/>
+              <rect x="149.4" y="19.8" fill="url(#droughtGradient)" width="17" height="80.3"/>
+              <rect x="178.1" y="19.8" fill="url(#droughtGradient)" width="39.2" height="80.3"/>
             </g>
             <g id="daily_streamflow">
               <use xlink:href="#stacked streamflow top mask"/>

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1610,7 +1610,6 @@
           </g>
           <g class="hidden" id="step-j">
             <use xlink:href="#axis"/>
-            <use xlink:href="#stacked variable threshold"/>
 
             <g id="variable droughts" class="drought">
               <rect x="17.4" y="216.7" width="11.8" height="7"/>
@@ -1622,6 +1621,7 @@
               <rect x="73.6" y="126.8" fill="url(#droughtGradient)" width="9.2" height="84.3"/>
               <rect x="149.4" y="126.8" fill="url(#droughtGradient)" width="15.7" height="84.3"/>
             </g>
+            <use xlink:href="#stacked variable threshold"/>
             <g id="daily_streamflow">
               <use xlink:href="#stacked streamflow bottom mask"/>
               <use xlink:href="#stacked streamflow bottom"/>
@@ -1636,13 +1636,13 @@
               <rect x="171.6" y="105.7" width="37.9" height="7"/>
               <rect x="210.8" y="105.7" width="17" height="7"/>
             </g>
-            <use xlink:href="#stacked fixed threshold"/>
             <g id="fixed droughts" class="drought">
               <rect x="149.4" y="105.7" width="17" height="7"/>
               <rect x="178.1" y="105.7" width="39.2" height="7"/>
               <rect x="149.4" y="19.8" fill="url(#droughtGradient)" width="17" height="80.3"/>
               <rect x="178.1" y="19.8" fill="url(#droughtGradient)" width="39.2" height="80.3"/>
             </g>
+            <use xlink:href="#stacked fixed threshold"/>
             <g id="daily_streamflow">
               <use xlink:href="#stacked streamflow top mask"/>
               <use xlink:href="#stacked streamflow top"/>


### PR DESCRIPTION
These changes reflect edits that were suggested by the larger drought project team. I changed some text to better incorporate human dimensions and updated some of the frames to include more labels, such as the final frame and the intro progression. In addition, the drought periods now fade out to white (THANKS HAYLEY!). 

Please let me know how you feel about the text changes in particular, and I look forward to your review of the other elements as well. 

![image](https://user-images.githubusercontent.com/19958841/202552969-54006a25-e4b9-43e4-869e-6dc1c7f282ac.png)

![image](https://user-images.githubusercontent.com/19958841/202553021-2ace24cc-9b53-4b5d-bf98-3d0d3ea72998.png)
