### PR TITLE
Accessibility keyboard fxn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13022,6 +13022,11 @@
         }
       }
     },
+    "vue-material-design-icons": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.1.2.tgz",
+      "integrity": "sha512-nD1qFM2qAkMlVoe23EfNKIeMfYl6YjHZjSty9q0mwc2gXmPmvEhixywJQhM+VF5KVBI1zAkVTNLoUEERPY10pA=="
+    },
     "vue-mobile-detection": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vue-mobile-detection/-/vue-mobile-detection-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vue-analytics": "^5.22.1",
     "vue-browser-detect-plugin": "^0.1.13",
     "vue-loader": "14.2.2",
+    "vue-material-design-icons": "^5.1.2",
     "vue-mobile-detection": "^1.0.0",
     "vue-router": "^3.4.3",
     "vue-svg-loader": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.30",
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
-    "@fortawesome/free-solid-svg-icons": "^5.14.0",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/vue-fontawesome": "^0.1.10",
     "core-js": "^3.6.5",
     "d3": "^6.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,8 +74,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;500;600;700;800&display=swap');
 $SourceSans: 'Source Sans Pro', sans-serif;
 $textcolor: #333534;
-@import url('https://fonts.googleapis.com/css2?family=Nanum+Pen+Script&display=swap');
-$writeFont: 'Nanum Pen Script', cursive;
 // whole page except header fit within viewport - no scrolling
 #app {
   width: 100%;

--- a/src/assets/text/scrollyText.js
+++ b/src/assets/text/scrollyText.js
@@ -5,67 +5,67 @@ export default {
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
-          id: 'aa01',
+          id: 'a',
           text: 'Drought is increasing for regions worldwide, threatening our water security and affecting our daily lives. What starts with reduced rain and snowfall can progress to impacts on soil moisture and streamflow.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
-          id: 'aa02',
+          id: 'b',
           text: 'When there is less rain or snowfall than typical, this is known as meteorological drought.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
-          id: 'aa03',
+          id: 'c',
           text: 'If meteorological drought continues, soil moisture becomes depleted and agricultural drought sets in. To keep crops and livestock healthy, farmers might use more water for irrigation. Extensive irrigation can impair water supplies and quality for local communities.'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
-          id: 'aa04',
+          id: 'd',
           text: 'As these conditions persist, less water moves into and through streams. Reduced streamflow has significant impact on plants, animals, and humans. When streamflow levels are unusually low, this is defined as streamflow drought. But what does "unusually low" really mean?'
         },
         {
           // id is used to source image files with the same naming
           // and used to assign classes to scrolling text
-          id: 'a',
+          id: 'e',
           text: 'Consider this Ohio streamgage site in the late summer of 1963. On August 15th there was a severe streamflow drought.'
         },
         {
-          id: 'b',
+          id: 'f',
           text: 'We can say that streamflow is "unusually low" whenever streamflow drops below a certain level or threshold. Here, that threshold was defined as 45 cubic feet per second (cfs). Why 45 cfs? There are two methods to choose that threshold, depending on the questions we are trying to answer.'
         },
         {
-          id: 'c',
+          id: 'g',
           text: 'To begin, we need to consider historical conditions. Over the past 70 years at this site in Ohio, average daily streamflow ranged from 100 to 2700 cfs, with August through October typically having the lowest daily streamflows during the year.'
         },
         {
-          id: 'd',
+          id: 'h',
           text: 'When considering records across the whole year, streamflow levels that fall below a threshold of 45 cfs are in the lowest 10%. This fixed threshold of 45 cfs is constant from day-to-day and identifies these streamflow drought events during the dry season when the lowest streamflow levels typically occur.'
         },
         {
-          id: 'e',
+          id: 'i',
           text: 'Using a 10% fixed threshold identifies two streamflow drought events for 1963 in the dry season. Unusually low flow at this time of year can reduce hydropower production, impair water quality, and require reservoir releases to provide water to communities. Notice that even if streamflow goes over the threshold for a brief time (up to about 5 days), this is still one drought event'
         },
         {
-          id: 'f',
+          id: 'j',
           text: 'But streamflow drought can also occur during wetter seasons if streamflow levels are unusually low for that time of year. To identify seasonal drought events, let\'s zoom out and look at the average daily streamflow for the last 70 years.'
         },
         {
-          id: 'g',
+          id: 'k',
           text: 'In 1963, spring streamflow was much lower than in a typical spring but still not as low as during the dry season.'
         },
         {
-          id: 'h',
+          id: 'l',
           text: 'To identify streamflow drought events during wetter times of the year, a variable threshold can be used to compare streamflow to typical conditions at that time of the year. Here, streamflow drought occurs if streamflow falls below the lowest 10% of observations ever recorded for that particular day. The result is a threshold that varies from day to day.'
         },
         {
-          id: 'i',
+          id: 'm',
           text: 'The variable threshold detects several streamflow drought events in the spring during the wet season. Low stream levels in the spring can reduce inflow to water supply reservoirs, affect the behavior and survival of aquatic species, and impact early season crops. This method also detects the drought in August, when streamflow was unusually low for even the dry season.'
         },
         {
-          id: 'j',
+          id: 'n',
           text: 'By pairing the two methods, we get a more comprehensive understanding of streamflow drought. This complete picture of drought patterns can inform water management, guide drought prediction, and help us use water more sustainably throughout the year.'
         }
         ]

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1868,7 +1868,7 @@ export default {
         this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-"+scrollFrame});
       },
       prevFxn(e) {
-        const currentFrame = document.querySelector('.visible'); // get svg element that is visible
+        const currentFrame = document.querySelector('#svg .visible'); // get svg element that is visible
         const currentFrameName = currentFrame.id; // full id name in format "step-x"
         const currentFrameLetter = currentFrameName.split('-')[1]
 
@@ -1878,7 +1878,7 @@ export default {
         this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-" + prevFrameLetter})
       },
       nextFxn(e) {
-        const currentFrame = document.querySelector('.visible'); // get svg element that is visible
+        const currentFrame = document.querySelector('#svg .visible'); // get svg element that is visible
         const currentFrameName = currentFrame.id; // full id name in format "step-x"
         const currentFrameLetter = currentFrameName.split('-')[1]
 

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,7 +1674,7 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
-          <button id="next" class="circleForm navCircle hidden" @click="prevFxn">
+          <button id="prev" class="circleForm navCircle hidden" @click="prevFxn">
             <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-left' }">test</font-awesome-icon>
           </button>
           <button

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1681,26 +1681,8 @@
           <button
             v-for="frame in frames"
             :key="frame.id"
-            :id="`grayCircle-${frame.id}`"
-            class="circleForm quietCircle hidden"
-          > 
-          </button>
-        </div>
-        <div class="topLayer">
-          <div 
-            v-for="frame in frames"
-            :key="frame.id"
-            :id="`step-${frame.id}`"
-            class="circleForm activeCircle hidden"
-          > 
-          </div>
-        </div>
-        <div class="hiddenLayer">
-          <button
-            v-for="frame in frames"
-            :key="frame.id"
             :id="`button-${frame.id}`"
-            class="circleForm hiddenCircle"
+            class="circleForm quietCircle hidden"
             @click="scrollFxn"> 
           </button>
         </div>
@@ -2071,7 +2053,7 @@ $usgsBlue: #032a56;
   margin: 0 auto;
   align-items: center;
 }
-.bottomLayer, .topLayer, .hiddenLayer{ //stacks the nav circle divs on top of each other
+.bottomLayer{ //stacks the nav circle divs on top of each other
   grid-column: 2;
   grid-row: 1;
 }
@@ -2095,19 +2077,16 @@ $usgsBlue: #032a56;
   border-radius: 50%;
   margin:0 2px 0 2px;
 }
+
+.quietCircle{ // color when inactive
+  background-color: #ccc;
+  border: none;
+}
 .activeCircle{ // color when active
   background-color: #507282;
   border-style: solid;
   border-width: 2px;
   border-color: #507282;
-}
-.quietCircle{ // color when inactive
-  background-color: #ccc;
-  border: none;
-}
-.hiddenCircle{ //overlaid invisible buttons
-  background-color: transparent;
-  border: none;
 }
 .navCircle{
   background-color: none;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -2062,7 +2062,7 @@ $usgsBlue: #032a56;
 }
 .navigationContainer{ // grid container for the navigation indicating circles
   grid-area: navigation;
-  position: fixed;
+  position: absolute;
   left: 50%;
   bottom: 20px;
   transform: translate(-50%, -50%);

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1673,6 +1673,26 @@
       >
         {{ frame.text }}
       </p>
+      <div class="navigationContainer">
+        <div class="bottomLayer">
+          <div 
+            v-for="frame in frames"
+            :key="frame.id"
+            :id="`step-${frame.id}`"
+            class="circleForm quietCircle"
+          > 
+          </div>
+        </div>
+        <div class="topLayer">
+          <div 
+            v-for="frame in frames"
+            :key="frame.id"
+            :id="`step-${frame.id}`"
+            class="circleForm activeCircle hidden"
+          > 
+          </div>
+        </div>
+      </div>
     </div>
     <!-- create a scrolling div for each frame -->
     <div id="scroll-container">
@@ -1684,7 +1704,7 @@
         </div>
     </div>
 
-    <div id="spacer" />
+    <div id="spacer"/>
     </div>
 </template>
 <script>
@@ -1710,7 +1730,7 @@ export default {
         margin: { top: 50, right: 50, bottom: 50, left: 50 },
 
         // show scroll trigger markers on the page?
-        marker_on: false,
+        marker_on: true,
 
         }
   },
@@ -1947,6 +1967,37 @@ $usgsBlue: #032a56;
   opacity: 0;
   transition: visibility 0s 0.5s, opacity 0.5s linear;
 }
+.navigationContainer{ // grid container for the navigation indicating circles
+  display: grid;
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translate(-50%, -50%);
+  margin: 0 auto;
+}
+.bottomLayer, .topLayer{ //stacks the nav circle divs on top of each other
+  grid-column: 1;
+  grid-row: 1;
+}
+.circleForm{ // circle shape and sizing
+  color: white;
+  width: 13px;
+  height: 13px;
+  display:inline-block;
+  border-radius: 50%;
+  margin:0 5px 0 0;
+}
+.activeCircle{ // color when active
+  background-color: #507282;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #507282;
+}
+.quietCircle{ // color when inactive
+  background-color: #ccc;
+  border: none;
+}
+
 
 .woodcutBlack {
   opacity: 0.8;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,6 +1674,15 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
+        <!--button>
+          v-for="frame in frames"
+          :key="frame.id"
+          :id="`current-${frame.id}`"
+          class="navCircle leftGrid"
+          @click="prevFxn">
+          Next
+        </button-->
+        <button id="prev" class="navCircle leftGrid" @click="prevFxn">PREV</button>
         <div class="bottomLayer">
           <button
             v-for="frame in frames"
@@ -1701,6 +1710,7 @@
             @click="scrollFxn"> 
           </button>
         </div>
+        <button id="next" class="navCircle rightGrid" @click="nextFxn">NEXT</button>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->
@@ -1752,6 +1762,8 @@ export default {
       // create the scrolling timeline
       let tl = this.$gsap.timeline(); 
 
+      
+
       // things that go before containers
             // use class to set trigger
          tl.to('.scroll-step-a', {
@@ -1769,7 +1781,7 @@ export default {
             onLeaveBack - scrolling up, start meets scroller-start
             */
           }
-        })  
+        }) 
 
 
 
@@ -1803,17 +1815,35 @@ export default {
           },
         }) 
       })
-
-      
-
     },
     methods:{
       scrollFxn(e) {
         const scrollButton = e.target; // define target
         const scrollID = scrollButton.id; // extract id as "button-x"
         const scrollFrame = scrollID.split('-')[1]; // extract frame number "x"
+        console.log(scrollID)
       // scroll to position of specified frame
         this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-"+scrollFrame});
+      },
+      prevFxn(e) {
+        const currentFrame = document.querySelector('.visible'); // get svg element that is visible
+        const currentFrameName = currentFrame.id; // full id name in format "step-x"
+        const currentFrameLetter = currentFrameName.split('-')[1]
+
+        const prevFrameLetter = String.fromCharCode(currentFrameLetter.charCodeAt(0) - 1); // prev letter
+
+        //scroll to previous
+        this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-" + prevFrameLetter})
+      },
+      nextFxn(e) {
+        const currentFrame = document.querySelector('.visible'); // get svg element that is visible
+        const currentFrameName = currentFrame.id; // full id name in format "step-x"
+        const currentFrameLetter = currentFrameName.split('-')[1]
+
+        const nextFrameLetter = String.fromCharCode(currentFrameLetter.charCodeAt(0) + 1); // prev letter
+
+        //scroll to previous
+        this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-"+nextFrameLetter})
       },
       isMobile() {
               if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
@@ -1994,10 +2024,23 @@ $usgsBlue: #032a56;
   bottom: 20px;
   transform: translate(-50%, -50%);
   margin: 0 auto;
+  align-items: start;
 }
 .bottomLayer, .topLayer, .hiddenLayer{ //stacks the nav circle divs on top of each other
+  grid-column: 2;
+  grid-row: 1;
+}
+.rightGrid{
+  grid-column: 3;
+  grid-row: 1;
+  margin:0 5px 0 0;
+  padding: 4px;
+}
+.leftGrid{
   grid-column: 1;
   grid-row: 1;
+  margin:0 5px 0 0;
+  padding: 4px;
 }
 .circleForm{ // circle shape and sizing
   color: white;
@@ -2020,6 +2063,14 @@ $usgsBlue: #032a56;
 .hiddenCircle{ //overlaid invisible buttons
   background-color: transparent;
   border: none;
+}
+.navCircle{
+  background-color: none;
+  color: black;
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  font-size: 12px;
 }
 .woodcutBlack {
   opacity: 0.8;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,15 +1674,7 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
-        <!--button>
-          v-for="frame in frames"
-          :key="frame.id"
-          :id="`current-${frame.id}`"
-          class="navCircle leftGrid"
-          @click="prevFxn">
-          Next
-        </button-->
-        <button id="prev" class="navCircle leftGrid" @click="prevFxn">PREV</button>
+        <button id="prev" class="navCircle leftGrid" @click="prevFxn">&#60;</button>
         <div class="bottomLayer">
           <button
             v-for="frame in frames"
@@ -1710,7 +1702,7 @@
             @click="scrollFxn"> 
           </button>
         </div>
-        <button id="next" class="navCircle rightGrid" @click="nextFxn">NEXT</button>
+        <button id="next" class="navCircle rightGrid" @click="nextFxn">&#62;</button>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->
@@ -1840,9 +1832,8 @@ export default {
         const currentFrameName = currentFrame.id; // full id name in format "step-x"
         const currentFrameLetter = currentFrameName.split('-')[1]
 
-        const nextFrameLetter = String.fromCharCode(currentFrameLetter.charCodeAt(0) + 1); // prev letter
-
-        //scroll to previous
+        const nextFrameLetter = String.fromCharCode(currentFrameLetter.charCodeAt(0) + 1); // next letter
+        //scroll to next
         this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-"+nextFrameLetter})
       },
       isMobile() {
@@ -1856,9 +1847,9 @@ export default {
 }
 </script>
 <style scoped lang="scss">
-// handwriting font
-@import url('https://fonts.googleapis.com/css2?family=Nanum+Pen+Script&display=swap');
-$writeFont: 'Nanum Pen Script', cursive;
+// sans serif font
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;500;600;700;800&display=swap');
+$SourceSans: 'Source Sans Pro', sans-serif;
 $base: 0.6rem; //for chevron scroll animation
 // frames are stacked and class is added on an off w/ scroll trigger to bring to front
 $usgsBlue: #032a56;
@@ -2024,7 +2015,7 @@ $usgsBlue: #032a56;
   bottom: 20px;
   transform: translate(-50%, -50%);
   margin: 0 auto;
-  align-items: start;
+  align-items: center;
 }
 .bottomLayer, .topLayer, .hiddenLayer{ //stacks the nav circle divs on top of each other
   grid-column: 2;
@@ -2033,22 +2024,22 @@ $usgsBlue: #032a56;
 .rightGrid{
   grid-column: 3;
   grid-row: 1;
-  margin:0 5px 0 0;
-  padding: 4px;
+  margin: 0 2px 0 2px;
+  padding: 0px;
 }
 .leftGrid{
   grid-column: 1;
   grid-row: 1;
-  margin:0 5px 0 0;
-  padding: 4px;
+  margin: 0 2px 0 2px;
+  padding: 0;
 }
 .circleForm{ // circle shape and sizing
   color: white;
   width: 13px;
   height: 13px;
-  display:inline-block;
+  display: inline-block;
   border-radius: 50%;
-  margin:0 5px 0 0;
+  margin:0 2px 0 2px;
 }
 .activeCircle{ // color when active
   background-color: #507282;
@@ -2067,10 +2058,11 @@ $usgsBlue: #032a56;
 .navCircle{
   background-color: none;
   color: black;
-  width: 20px;
-  height: 20px;
+  width: 13px;
+  height: 13px;
   display: inline-block;
   font-size: 12px;
+  font-family: $SourceSans;
 }
 .woodcutBlack {
   opacity: 0.8;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1907,11 +1907,12 @@ $usgsBlue: #032a56;
 .grid-container{
   display: grid;
   grid-template-columns: 3fr 0.5fr;
-  grid-template-rows: auto 10em auto;
+  grid-template-rows: auto 10em auto 10em;
   grid-template-areas:
     "title chevron"
     "textbox textbox"
-    "chart chart";
+    "chart chart"
+    "navigation navigation";
   justify-content: center;
   margin: auto;
   width:95vw;
@@ -1923,10 +1924,11 @@ $usgsBlue: #032a56;
     width: 70vw;
     max-width: 1400px;
     grid-template-columns: minmax(100px, 400px) auto 1fr;
-    grid-template-rows: 0.5fr 3fr;
+    grid-template-rows: 0.5fr 3fr 0.2fr;
     grid-template-areas:
       "title title chevron"
       "textbox chart chart"
+      "navigation navigation navigation";
   }
 }
 .title-text {
@@ -2059,6 +2061,7 @@ $usgsBlue: #032a56;
   transition: visibility 0s 0.5s, opacity 0.5s linear;
 }
 .navigationContainer{ // grid container for the navigation indicating circles
+  grid-area: navigation;
   position: fixed;
   left: 50%;
   bottom: 20px;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,13 +1674,13 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
-        <button id="prev" class="navCircle leftGrid" @click="prevFxn">&#60;</button>
+        <button id="prev" class="navCircle leftGrid hidden" @click="prevFxn">&#60;</button>
         <div class="bottomLayer">
           <button
             v-for="frame in frames"
             :key="frame.id"
             :id="`grayCircle-${frame.id}`"
-            class="circleForm quietCircle"
+            class="circleForm quietCircle hidden"
           > 
           </button>
         </div>
@@ -1702,7 +1702,7 @@
             @click="scrollFxn"> 
           </button>
         </div>
-        <button id="next" class="navCircle rightGrid" @click="nextFxn">&#62;</button>
+        <button id="next" class="navCircle rightGrid hidden" @click="nextFxn">&#62;</button>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->
@@ -1743,7 +1743,7 @@ export default {
         margin: { top: 50, right: 50, bottom: 50, left: 50 },
 
         // show scroll trigger markers on the page?
-        marker_on: true,
+        marker_on: false,
 
         }
   },
@@ -1781,15 +1781,13 @@ export default {
       const containers = this.$gsap.utils.toArray(".scrolly");
 
       //  add scroll trigger to timeline for each step
-      containers.forEach((container) => {
-
+      containers.forEach((container, i) => {
         // get unique ID and class for frame. Scroll frame classes follow the pattern `scrolly scroll-step-${frame.id}`
         let classList = container.className
         let scrollClass = classList.split(' ')[1]
-        console.log(scrollClass.split('-')[2])
         let scrollID = scrollClass.split('-')[2] // ending of class is unique ID from scrollyText.js
-
-      // use class to set trigger
+        
+        // use class to set trigger
         tl.to(`.${scrollClass}`, {
           scrollTrigger: {
             markers: this.marker_on,
@@ -1806,6 +1804,58 @@ export default {
             */
           },
         }) 
+        if (i == 0) {
+          tl.to(`.${scrollClass}`, {
+            scrollTrigger: {
+              markers: this.marker_on,
+              trigger: `.${scrollClass}`,
+              start: "top 54%",
+              end: 99999,
+              toggleClass: {targets: ['.quietCircle', "#next"], className:"visible"}, // adds class to target when triggered
+              toggleActions: "restart none none reverse" 
+              /*
+              onEnter - scrolling down, start meets scroller-start
+              onLeave - scrolling down, end meets scroller-end
+              onEnterBack - scrolling up, end meets scroller-end
+              onLeaveBack - scrolling up, start meets scroller-start
+              */
+            },
+          })
+        }
+        if (i == 1) {
+          tl.to(`.${scrollClass}`, {
+            scrollTrigger: {
+              markers: this.marker_on,
+              trigger: `.${scrollClass}`,
+              start: "top 54%",
+              end: 99999,
+              toggleClass: {targets: "#prev", className:"visible"}, // adds class to target when triggered
+              toggleActions: "restart none none reverse" 
+              /*
+              onEnter - scrolling down, start meets scroller-start
+              onLeave - scrolling down, end meets scroller-end
+              onEnterBack - scrolling up, end meets scroller-end
+              onLeaveBack - scrolling up, start meets scroller-start
+              */
+            },
+          })
+        }
+        if (i == (containers.length-1)) {
+          tl.to(`.${scrollClass}`, {
+            scrollTrigger: {
+              markers: this.marker_on,
+              trigger: `.${scrollClass}`,
+              start: "top 54%",
+              end: "top 54%",
+              onEnter: () => {
+                document.querySelector("#next").classList.remove("visible");
+              },
+              onLeaveBack: () => {
+                document.querySelector("#next").classList.add("visible");
+              }
+            },
+          })
+        }
       })
     },
     methods:{

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1276,7 +1276,7 @@
             </linearGradient>
           </defs>
 
-          <g class="hidden" id="step-aa01">
+          <g class="hidden" id="step-a">
             <use xlink:href="#sun"/>
             <g class="grass"><use xlink:href="#grass"/></g>
             <use xlink:href="#river"/>
@@ -1308,7 +1308,7 @@
             </g>
           </g>
             
-          <g class="hidden" id="step-aa02">
+          <g class="hidden" id="step-b">
             <use xlink:href="#sun"/>
             <g class="dry_grass"><use xlink:href="#grass"/></g>
             <use xlink:href="#river"/>
@@ -1339,7 +1339,7 @@
             </g>
           </g>
 
-          <g class="hidden" id="step-aa03">
+          <g class="hidden" id="step-c">
             <use xlink:href="#sun"/>
             <g class="sad_grass"><use xlink:href="#grass"/></g>
             <use xlink:href="#river"/>
@@ -1370,7 +1370,7 @@
             </g>
           </g>
 
-          <g class="hidden" id="step-aa04">
+          <g class="hidden" id="step-d">
             <use xlink:href="#sun"/>
             <g class="dead_grass"><use xlink:href="#grass"/></g>
             <use xlink:href="#grass-texture"/>
@@ -1400,7 +1400,7 @@
             </g>
           </g>
 
-          <g class="hidden" id="step-a">
+          <g class="hidden" id="step-e">
             <use xlink:href="#axis"/>
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
@@ -1417,7 +1417,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-b">
+          <g class="hidden" id="step-f">
             <use xlink:href="#axis"/>
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
@@ -1429,7 +1429,7 @@
             <text transform="matrix(1 0 0 1 56.64 60.68)" class="streamtext">Daily</text>
             <text transform="matrix(1 0 0 1 56.64 68.87)" class="streamtext">streamflow</text>
           </g>
-          <g class="hidden" id="step-b">
+          <g class="hidden" id="step-f">
             <circle class="inset"  cx="158.5" cy="110" r="57"/>
             <g>
               <polygon class="drought fade" points="132.3,118 134,118 138.3,118 142.5,118 146.8,118 151.1,118 155.3,118 159.6,118 163.8,118 
@@ -1457,7 +1457,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-c">
+          <g class="hidden" id="step-g">
             <use xlink:href="#axis"/>
             <use xlink:href="#daily streamflow mask"/>
             <use xlink:href="#daily streamflow"/>
@@ -1470,7 +1470,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-d">
+          <g class="hidden" id="step-h">
             <use xlink:href="#axis"/>
             <use xlink:href="#fixed threshold"/>
             <text transform="matrix(1 0 0 1 31.81 198.53)" class="threshtext">Drought threshold</text>
@@ -1485,7 +1485,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-e">
+          <g class="hidden" id="step-i">
             <use xlink:href="#axis"/>
             <g class="drought">
               <rect x="149.4" y="216.6" width="17" height="7.1"/>
@@ -1506,7 +1506,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-f">
+          <g class="hidden" id="step-j">
             <use xlink:href="#axis"/>
             <g id="average_streamflow">
               <use xlink:href="#average streamflow"/>
@@ -1528,7 +1528,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-g">
+          <g class="hidden" id="step-k">
             <use xlink:href="#axis"/>
             <g id="average_streamflow">
               <use xlink:href="#average streamflow"/>
@@ -1560,7 +1560,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-h">
+          <g class="hidden" id="step-l">
             <use xlink:href="#axis"/>
             <use xlink:href="#scaled variable threshold"/>
             <g id="average_streamflow">
@@ -1582,7 +1582,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-i">
+          <g class="hidden" id="step-m">
             <use xlink:href="#axis"/>
             <g id="variable_droughts" class="drought">
               <rect x="17.4" y="216.6" width="11.8" height="7.1"/>
@@ -1608,7 +1608,7 @@
               <text transform="matrix(1 0 0 1 194 62)">drought</text>
             </g>
           </g>
-          <g class="hidden" id="step-j">
+          <g class="hidden" id="step-n">
             <use xlink:href="#axis"/>
 
             <g id="variable droughts" class="drought">
@@ -1754,10 +1754,10 @@ export default {
 
       // things that go before containers
             // use class to set trigger
-         tl.to('.scroll-step-aa01', {
+         tl.to('.scroll-step-a', {
           scrollTrigger: {  
             markers: this.marker_on,
-            trigger: '.scroll-step-aa01',
+            trigger: '.scroll-step-a',
             start: "top 65%",
             end: 99999,
             toggleClass: {targets: `.title-text`, className:"title-text--scrolled"}, // adds class to target when triggered

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,10 +1674,9 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
-        <button id="next" class="navCircle leftGrid hidden" @click="prevFxn">
-          <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-left' }">test</font-awesome-icon>
-        </button>
-        <div class="bottomLayer">
+          <button id="next" class="circleForm navCircle hidden" @click="prevFxn">
+            <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-left' }">test</font-awesome-icon>
+          </button>
           <button
             v-for="frame in frames"
             :key="frame.id"
@@ -1685,10 +1684,9 @@
             class="circleForm quietCircle hidden"
             @click="scrollFxn"> 
           </button>
-        </div>
-        <button id="next" class="navCircle rightGrid hidden" @click="nextFxn">
-          <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-right' }">test</font-awesome-icon>
-        </button>
+          <button id="next" class="circleForm navCircle hidden" @click="nextFxn">
+            <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-right' }">test</font-awesome-icon>
+          </button>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->
@@ -1781,6 +1779,22 @@ export default {
             start: "top 54%",
             end: "bottom 54%",
             toggleClass: {targets: `#step-${scrollID}`, className:"visible"}, // adds class to target when triggered
+            toggleActions: "restart reverse none reverse" 
+            /*
+            onEnter - scrolling down, start meets scroller-start
+            onLeave - scrolling down, end meets scroller-end
+            onEnterBack - scrolling up, end meets scroller-end
+            onLeaveBack - scrolling up, start meets scroller-start
+            */
+          },
+        }) 
+        tl.to(`.${scrollClass}`, {
+          scrollTrigger: {
+            markers: this.marker_on,
+            trigger: `.${scrollClass}`,
+            start: "top 54%",
+            end: "bottom 54%",
+            toggleClass: {targets: `#button-${scrollID}`, className:"activeCircle"}, // adds class to target when triggered
             toggleActions: "restart reverse none reverse" 
             /*
             onEnter - scrolling down, start meets scroller-start
@@ -2045,29 +2059,11 @@ $usgsBlue: #032a56;
   transition: visibility 0s 0.5s, opacity 0.5s linear;
 }
 .navigationContainer{ // grid container for the navigation indicating circles
-  display: grid;
   position: fixed;
   left: 50%;
   bottom: 20px;
   transform: translate(-50%, -50%);
   margin: 0 auto;
-  align-items: center;
-}
-.bottomLayer{ //stacks the nav circle divs on top of each other
-  grid-column: 2;
-  grid-row: 1;
-}
-.rightGrid{
-  grid-column: 3;
-  grid-row: 1;
-  margin: 0 2px 0 2px;
-  padding: 0px;
-}
-.leftGrid{
-  grid-column: 1;
-  grid-row: 1;
-  margin: 0 2px 0 2px;
-  padding: 0;
 }
 .circleForm{ // circle shape and sizing
   color: white;
@@ -2081,6 +2077,9 @@ $usgsBlue: #032a56;
 .quietCircle{ // color when inactive
   background-color: #ccc;
   border: none;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #ccc;
 }
 .activeCircle{ // color when active
   background-color: #507282;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1675,13 +1675,13 @@
       </p>
       <div class="navigationContainer">
         <div class="bottomLayer">
-          <div 
+          <button
             v-for="frame in frames"
             :key="frame.id"
-            :id="`step-${frame.id}`"
+            :id="`grayCircle-${frame.id}`"
             class="circleForm quietCircle"
           > 
-          </div>
+          </button>
         </div>
         <div class="topLayer">
           <div 
@@ -1692,6 +1692,15 @@
           > 
           </div>
         </div>
+        <div class="hiddenLayer">
+          <button
+            v-for="frame in frames"
+            :key="frame.id"
+            :id="`button-${frame.id}`"
+            class="circleForm hiddenCircle"
+            @click="scrollFxn"> 
+          </button>
+        </div>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->
@@ -1699,6 +1708,7 @@
         <div
           v-for="frame in frames" 
           :key="frame.id"
+          :id="`scroll-to-${frame.id}`"
           :class="`scrolly scroll-step-${frame.id}`"
         >
         </div>
@@ -1711,6 +1721,7 @@
 import { store } from '../store/store.js'
 import { isMobile } from 'mobile-device-detect';
 import { ScrollTrigger } from "gsap/ScrollTrigger"; // animated scroll events
+import { ScrollToPlugin } from "gsap/ScrollToPlugin";
 import scrollyText from "@/assets/text/scrollyText";  // step text
 export default {
   name: "DroughtThresholds",
@@ -1736,7 +1747,7 @@ export default {
   },
   mounted(){      
     // register plugins for global use
-      this.$gsap.registerPlugin(ScrollTrigger); 
+      this.$gsap.registerPlugin(ScrollTrigger, ScrollToPlugin); 
 
       // create the scrolling timeline
       let tl = this.$gsap.timeline(); 
@@ -1747,7 +1758,7 @@ export default {
           scrollTrigger: {  
             markers: this.marker_on,
             trigger: '.scroll-step-aa01',
-            start: "top 70%",
+            start: "top 65%",
             end: 99999,
             toggleClass: {targets: `.title-text`, className:"title-text--scrolled"}, // adds class to target when triggered
             toggleActions: "restart none none none" // onEnter onLeave ... ... restart none none none
@@ -1779,8 +1790,8 @@ export default {
           scrollTrigger: {
             markers: this.marker_on,
             trigger: `.${scrollClass}`,
-            start: "top 70%",
-            end: "bottom 70%",
+            start: "top 54%",
+            end: "bottom 54%",
             toggleClass: {targets: `#step-${scrollID}`, className:"visible"}, // adds class to target when triggered
             toggleActions: "restart reverse none reverse" 
             /*
@@ -1793,8 +1804,17 @@ export default {
         }) 
       })
 
+      
+
     },
     methods:{
+      scrollFxn(e) {
+        const scrollButton = e.target; // define target
+        const scrollID = scrollButton.id; // extract id as "button-x"
+        const scrollFrame = scrollID.split('-')[1]; // extract frame number "x"
+      // scroll to position of specified frame
+        this.$gsap.to(window, {duration: 0, scrollTo:"#scroll-to-"+scrollFrame});
+      },
       isMobile() {
               if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
                   return true
@@ -1883,9 +1903,9 @@ $usgsBlue: #032a56;
 }
 // currently empty scroll-by divs used to trigger animation
 .scrolly{
-  height:60vh;
+  height:55vh;
   @media (min-width: 950px){
-    height:50vh;
+    height:55vh;
   }
 }
 .hydro-chart {
@@ -1975,7 +1995,7 @@ $usgsBlue: #032a56;
   transform: translate(-50%, -50%);
   margin: 0 auto;
 }
-.bottomLayer, .topLayer{ //stacks the nav circle divs on top of each other
+.bottomLayer, .topLayer, .hiddenLayer{ //stacks the nav circle divs on top of each other
   grid-column: 1;
   grid-row: 1;
 }
@@ -1997,8 +2017,10 @@ $usgsBlue: #032a56;
   background-color: #ccc;
   border: none;
 }
-
-
+.hiddenCircle{ //overlaid invisible buttons
+  background-color: transparent;
+  border: none;
+}
 .woodcutBlack {
   opacity: 0.8;
   fill: #202020; 

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -1674,7 +1674,9 @@
         {{ frame.text }}
       </p>
       <div class="navigationContainer">
-        <button id="prev" class="navCircle leftGrid hidden" @click="prevFxn">&#60;</button>
+        <button id="next" class="navCircle leftGrid hidden" @click="prevFxn">
+          <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-left' }">test</font-awesome-icon>
+        </button>
         <div class="bottomLayer">
           <button
             v-for="frame in frames"
@@ -1702,7 +1704,9 @@
             @click="scrollFxn"> 
           </button>
         </div>
-        <button id="next" class="navCircle rightGrid hidden" @click="nextFxn">&#62;</button>
+        <button id="next" class="navCircle rightGrid hidden" @click="nextFxn">
+          <font-awesome-icon :icon="{ prefix: 'fas', iconName: 'arrow-right' }">test</font-awesome-icon>
+        </button>
       </div>
     </div>
     <!-- create a scrolling div for each frame -->

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faFlickr } from "@fortawesome/free-brands-svg-icons";
 import { faYoutubeSquare } from "@fortawesome/free-brands-svg-icons";
 import { faInstagram } from "@fortawesome/free-brands-svg-icons";
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import gsap from "gsap";
 
 const vueImgConfig = {
@@ -36,6 +37,7 @@ library.add(faGithub);
 library.add(faFlickr);
 library.add(faYoutubeSquare);
 library.add(faInstagram);
+library.add(faArrowLeft, faArrowRight);
 
 Vue.config.productionTip = false;
 Vue.use(uswds);


### PR DESCRIPTION
This pull request has changes to the website that are all related to increasing the ability for focusable keyboard navigation of the progression through the slides. Prior to this, the only option to advance through the website with keyboard controls was with page-down or page-up buttons, which advanced the slides too far and skipped parts of the progression.

To build the navigation timeline buttons (grey circles), I added three layers of circles. Bottom layer are to see the entire progress at once, middle layer turns on the "active" button for that particular frame in the progression to show where reader is along the way, and top layer is invisible but has the button interaction to chose a different part of the timeline.

To build the forward and backward chevrons, I'm currently using an ascii symbol. I think an improvement would be in the future to have an actual circular "forward" or "backward" icon from font awesome.

To review this request, pull changes and run `nvm use 14.17.0`, `npm install` and `npm run serve' 

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/19958841/205656416-0644d226-f325-4881-8d13-88a9d84732b6.png">
