### PR TITLE
Add meta card

### DIFF
--- a/public/container.html
+++ b/public/container.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+
+  <title>video player</title>
+  <style type="text/css">
+    video {
+      width: 100%;
+      max-width: 600px;
+      height: auto;
+    }
+  </style>
+
+  <video controls>
+    <source src="https://labs.waterdata.usgs.gov/visualizations/mp4s/what-is-drought.mp4" type="video/mp4">
+    Your browser does not support video
+  </video>
+
+</body>
+
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
+    <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application. blocks google from indexing test or beta pages   -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-76090PESLN"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -51,8 +51,8 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
-        "@type": "WebSite", "name": "What is hydrological drought?",
-        "url": "https://labs.waterdata.usgs.gov/visualizations/IRB-algal-blooms/index.html#/",
+        "@type": "WebSite", "name": "What is streamflow drought?",
+        "url": "https://labs-beta.waterdata.usgs.gov/visualizations/what-is-drought/index.html#/",
         "about": "",
         "datePublished": "FILL THIS OUT",
         "contributor": [

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta content='text/html' charset="utf-8" http-equiv='Content-Type'>
+    <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
@@ -24,10 +24,7 @@
 
       gtag('config', 'G-QV1JK700W8');
     </script>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
+    <!-- End gtag -->
     <!-- Primary Meta Tags -->
     <title>
       <%= VUE_APP_TIER %>

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta content='text/html' charset="utf-8" http-equiv='Content-Type'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-76090PESLN"></script>
@@ -11,31 +15,44 @@
 
       gtag('config', 'G-76090PESLN');
     </script>
+    <!-- VIZLAB DATA STREAM Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QV1JK700W8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-QV1JK700W8');
+    </script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
-      <!-- Primary Meta Tags -->
-      <title>
-        <%= VUE_APP_TIER %>
-          <%= VUE_APP_TITLE %>
-      </title>
-      <meta name="title" content="What is hydrological drought?">
-      <meta name="description" content="">
-      <!-- Open Graph / Facebook -->
-      <meta property="og:type" content="website">
-      <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
-      <meta property="og:title" content="What is hydrological drought?">
-      <meta property="og:description" content="">
-      <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
-      <!-- Twitter -->
-      <meta property="twitter:card" content="summary_large_image">
-      <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
-      <meta property="twitter:title" content="What is hydrological drought?">
-      <meta property="twitter:description" content="">
-      <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
+    <!-- Primary Meta Tags -->
+    <title>
+      <%= VUE_APP_TIER %>
+        <%= VUE_APP_TITLE %>
+    </title>
+    <meta name="title" content="What is streamflow drought?">
+    <meta name="description" content="">
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://labs-beta.waterdata.usgs.gov/visualizations/what-is-drought/index.html#/">
+    <meta property="og:title" content="What is streamflow drought?">
+    <meta property="og:description" content="">
+    <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/gifs/what-is-drought.gif">
+    <!-- Twitter -->
+    <meta name="twitter:card" content="player">
+    <meta name="twitter:url" content="https://labs-beta.waterdata.usgs.gov/visualizations/what-is-drought/index.html#/">
+    <meta name="twitter:title" content="What is streamflow drought?">
+    <meta name="twitter:description" content="">
+    <meta name="twitter:site:id" content="@USGS_DataSci">
+    <meta name="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/gifs/what-is-drought.gif" />
+    <meta name="twitter:player" content="https://labs-beta.waterdata.usgs.gov/visualizations/what-is-drought/container.html#/">
+    <meta name="twitter:player:width" content="480">
+    <meta name="twitter:player:height" content="480">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-<script type='application/ld+json'>
+    <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
         "@type": "WebSite", "name": "What is hydrological drought?",
         "url": "https://labs.waterdata.usgs.gov/visualizations/IRB-algal-blooms/index.html#/",


### PR DESCRIPTION
From the [twitter card guidelines](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup), seems like an animated gif will not play if used in place of a png:

> twitter:image. URL of image to use in the card. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. **Only the first frame of an animated GIF will be used**. SVG is not supported.

This is an attempt to set up a [player card](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card) w/ an `mp4`, following the [twitter example](https://github.com/twitterdev/cards-player-samples). Unclear if the content will autoplay, though, based on [this post](https://twittercommunity.com/t/animated-gifs-are-currently-supported-in-twitter-cards-via-the-player-card-but-how/16825)

If this works, it may or may not be possible to sub in a gif for the mp4 - see [post](https://stackoverflow.com/questions/30023417/animated-gifs-with-twitter-player-card-not-working)