### PR TITLE
switch to summary card

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
     <meta property="og:description" content="">
     <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/images/what-is-drought.png">
     <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary">
     <meta name="twitter:url" content="https://labs-beta.waterdata.usgs.gov/visualizations/what-is-drought/index.html#/">
     <meta name="twitter:title" content="What is streamflow drought?">
     <meta name="twitter:description" content="">


### PR DESCRIPTION
Switching to a summary card, which uses a 1:1 aspect ratio image

The current image didn't work for a `summary_large_image` tag, as that image has a 2:1 aspect ratio - my bad:
![image](https://user-images.githubusercontent.com/54007288/232145956-0d00c26f-18a4-4bf1-9742-987115462c1c.png)
