### PR TITLE
Adjust mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -242,6 +242,7 @@ sup {
 }
 .sticky-header {
   position: fixed;
+  z-index: 5;
   top: 0;
   left: 0;
   width: 100vw;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -2835,7 +2835,7 @@ $usgsBlue: #032a56;
 .grid-container{
   display: grid;
   grid-template-columns: 3fr 0.5fr;
-  grid-template-rows: auto 10em auto 10em;
+  grid-template-rows: auto 10em auto 3em;
   grid-template-areas:
     "title chevron"
     "textbox textbox"
@@ -2847,7 +2847,7 @@ $usgsBlue: #032a56;
   position: sticky;
   left: 10px;
   top: 81px;
-  height: 88vh;
+  height: 86vh;
   @media (min-width: 950px){
     width: 70vw;
     max-width: 1400px;
@@ -2857,6 +2857,7 @@ $usgsBlue: #032a56;
       "title title chevron"
       "textbox chart chart"
       "navigation navigation navigation";
+      height: 88vh;
   }
 }
 .title-text {
@@ -2880,13 +2881,14 @@ $usgsBlue: #032a56;
   justify-self: center;
   height: 95%;
   width: 95%;
-  max-height: 60vh;
+  max-height: 40vh;
   display: flex;
     display: -webkit-flex;
     justify-content: space-between;
     -webkit-justify-content: space-between;
   @media (min-width: 950px){
     height: 60vh;
+    max-height: 60vh;
   }
 }
 .textBox {
@@ -2995,7 +2997,14 @@ $usgsBlue: #032a56;
   left: 50%;
   bottom: 20px;
   transform: translate(-50%, -50%);
+  top: 1em;
   margin: 0 auto;
+  width: 95vw;
+  align-self: center;
+  text-align: center;
+  @media (min-width: 950px){
+    width: auto;
+  }
 }
 .circleForm{ // circle shape and sizing
   color: white;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -2906,7 +2906,7 @@ $usgsBlue: #032a56;
 }
 // currently empty scroll-by divs used to trigger animation
 .scrolly{
-  height:55vh;
+  height:85vh;
   @media (min-width: 950px){
     height:55vh;
   }


### PR DESCRIPTION
This PR is the first attempt to address #61 

### Issue 1 - mobile scroll speed
* Increased the height of the `.scrolly` divs on mobile to 85vh from 55vh. Will need to build on beta and test on mobile device

### Issue 2 -  nav bar out of view
* Set `max-height` for `#hydro-chart-container` on mobile, as it was expanding the height of the grid and pushing the nav-bar row out of view
* Reduced height of nav-bar row in `.grid-container`
* Slightly reduced overall height of `.grid-container` on mobile
* Styled the `.navigation-container` to center content, add a top positioning style to give it a bit of buffer from the hydro chart, and set the width on the mobile, so that the nav bar doesn't wrap into two rows

### Additional edit
* Currently because the header is `position: fixed`, the z-index was automatically 0 and the text ran over it -I thought it looked a bit weird on mobile:
![image](https://user-images.githubusercontent.com/54007288/234074552-de2afc72-58e9-4adc-a62c-f1997c2459ba.png)

* I added a `z-index: 5` to `.sticky-header`, so the text now goes beneath the header: 
![image](https://user-images.githubusercontent.com/54007288/234074410-741219ba-de0c-4861-98c1-8d5292d4db45.png)
* let me know if you'd like me to revert that change or modify the styling in any way