### PR TITLE
repoint docker image to stable debian release tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.wma.chs.usgs.gov/docker-official-mirror/debian:stretch
+FROM artifactory.wma.chs.usgs.gov/docker-official-mirror/debian:stable
 
 LABEL maintainer="gw-w_vizlab@usgs.gov"
 


### PR DESCRIPTION
Per David's advice, re-point the docker image to a stable debian release, instead of the archived `stretch` release, using the `debian:stable` tag listed as a current tag [on Dockerhub](https://hub.docker.com/_/debian/tags).