### PR TITLE
remove duplicate code

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -10,7 +10,6 @@ pipeline {
         choice(choices: ['test', 'beta', 'prod'], description: 'The mode selected will tell Vue which environment variables to use. Various feature flags will be disabled/enabled depending on mode. More importantly, the source of the tiles will change, with the development build loading tiles from the test S3 bucket and the production build loading tiles from the prod S3 bucket.', name: 'VUE_BUILD_MODE')
         choice(choices: ['what-is-drought'], description: 'project name, url extension, and GitLab repository name, matching VITE_APP_TITLE set in .env', name: 'VITE_APP_TITLE')
         gitParameter(name: 'BRANCH_TAG',
-        gitParameter(name: 'BRANCH_TAG',
                      type: 'PT_BRANCH_TAG',
                      selectedValue: 'DEFAULT',
                      defaultValue: 'origin/main')


### PR DESCRIPTION
Fix a typo where `gitParameter()` had duplicate code in `Jenkinsfile.build`