### PR TITLE
fix copy pasta repo url in Jenkinsfile.build

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -29,7 +29,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: "https://code.usgs.gov/wma/vizlab/${params.VITE_APP_TITLE}.git"]]
+                          userRemoteConfigs: [[url: "https://github.com/usgs-vizlab/${params.VITE_APP_TITLE}.git"]]
                         ])
                 }
         }


### PR DESCRIPTION
More copy pasta on my part. Url in `Jenkinsfile.build` should point to repo on GitHub, not GitLab.