### PR TITLE
Update nodejs installation script - specify v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,9 @@ RUN apt-get update && \
       apt-get purge -y --auto-remove && \
       apt-get clean
 
-# Enable the NodeSource repository and install the latest nodejs
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-      NODE_MAJOR=20 && \
-      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-      apt-get update && \
-      apt-get install nodejs -y
+# Enable the NodeSource repository and install nodejs version 20 (current LTS as of April 2024)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&\
+      apt-get install -y nodejs
 
 # Create temp directory for building viz app
 ARG VITE_APP_TITLE="project"


### PR DESCRIPTION
This MR updates the `nodejs` installation script in `Dockerfile`, as the installation scripts have reverted to the old version-specific syntax (see [GitHub docs](https://github.com/nodesource/distributions?tab=readme-ov-file#installation-instructions)). We still are explicitly installing `nodejs` version 20 -- the current long term support version, [as of April 2024](https://github.com/nodesource/distributions?tab=readme-ov-file#nodejs-release-calendar).