### PR TITLE
use s3 prod url, remove labs references

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,20 +27,20 @@
     <meta name="description" content="%VITE_APP_DESCRIPTION%">
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/%VITE_APP_TITLE%">
+    <meta property="og:url" content="https://water.usgs.gov/vizlab/%VITE_APP_TITLE%">
     <meta property="og:title" content="%VITE_APP_LONG_TITLE%">
     <meta property="og:description" content="%VITE_APP_DESCRIPTION%">
-    <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/images/%VITE_APP_TITLE%_metacard.webp">
+    <meta property="og:image" content="%VITE_APP_S3_PROD_URL%images/%VITE_APP_TITLE%_metacard.webp">
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/%VITE_APP_TITLE%">
+    <meta property="twitter:url" content="https://water.usgs.gov/vizlab/%VITE_APP_TITLE%">
     <meta property="twitter:title" content="%VITE_APP_LONG_TITLE%">
     <meta property="twitter:description" content="%VITE_APP_DESCRIPTION%">
-    <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/images/%VITE_APP_TITLE%_metacard.webp">
+    <meta property="twitter:image" content="%VITE_APP_S3_PROD_URL%images/%VITE_APP_TITLE%_metacard.webp">
     <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
         "@type": "WebSite", "name": "What is streamflow drought?",
-        "url": "https://labs.waterdata.usgs.gov/visualizations/what-is-drought/index.html#/",
+        "url": "https://water.usgs.gov/vizlab/what-is-drought/index.html#/",
         "about": "How can USGS streamgage data be used to characterize drought?",
         "datePublished": "June 1, 2023",
         "contributor": [


### PR DESCRIPTION
Updates the `index.html` to:
* Use the s3 prod url for the metacard image paths, instead of the labs url
* Updates metcard urls to the new domain urls