### PR TITLE
fix svg sizing and font sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,13 +30,13 @@
     <meta property="og:url" content="https://water.usgs.gov/vizlab/%VITE_APP_TITLE%">
     <meta property="og:title" content="%VITE_APP_LONG_TITLE%">
     <meta property="og:description" content="%VITE_APP_DESCRIPTION%">
-    <meta property="og:image" content="%VITE_APP_S3_PROD_URL%images/%VITE_APP_TITLE%_metacard.webp">
+    <meta property="og:image" content="%VITE_APP_S3_PROD_URL%thumbnails/%VITE_APP_TITLE%_metacard.png">
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://water.usgs.gov/vizlab/%VITE_APP_TITLE%">
     <meta property="twitter:title" content="%VITE_APP_LONG_TITLE%">
     <meta property="twitter:description" content="%VITE_APP_DESCRIPTION%">
-    <meta property="twitter:image" content="%VITE_APP_S3_PROD_URL%images/%VITE_APP_TITLE%_metacard.webp">
+    <meta property="twitter:image" content="%VITE_APP_S3_PROD_URL%thumbnails/%VITE_APP_TITLE%_metacard.png">
     <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
         "@type": "WebSite", "name": "What is streamflow drought?",

--- a/src/components/HeaderUSWDSBanner.vue
+++ b/src/components/HeaderUSWDSBanner.vue
@@ -121,18 +121,83 @@
     width: 1.6rem;
     margin-right: 0.75rem;
   }
-  .usa-banner__header-text {
-    font-size: 1.4rem;
-  }
   .usa-banner__button {
-    font-size: 1.4rem;
     color: #78B4E8;
+  }
+  .usa-accordion__button[aria-expanded=false] {
+    background-size: 2.4rem;
+  }
+  @media (min-width: 600px) {
+    .usa-banner__header-text {
+      font-size: 1.5rem;
+    }
+    .usa-banner__button {
+      font-size: 1.5rem;
+    }
+    .usa-banner__button::after {
+      background-size:1.6rem 1.6rem;
+      height: 1.6rem;
+      width: 1.6rem;
+    }
+    .usa-banner__button[aria-expanded=true]::after {
+      height: 1.6rem;
+      width: 1.6rem;
+    }
+    @supports ((-webkit-mask: url("")) or (mask: url(""))) {
+      .usa-banner__button::after {
+        -webkit-mask-size: 1.6rem 1.6rem;
+        mask-size: 1.6rem 1.6rem;
+      }
+      .usa-banner__button[aria-expanded=true]::after {
+        -webkit-mask-size: 1.6rem 1.6rem;
+        mask-size: 1.6rem 1.6rem;
+      }
+    }
+  }
+  .usa-banner__header-action::after{
+    background-size:1.6rem 1.6rem;
+    height: 1.6rem;
+    width: 1.6rem;
+  }
+  @supports ((-webkit-mask: url("")) or (mask: url(""))){
+    .usa-banner__header-action::after{
+      -webkit-mask-size:1.6rem 1.6rem;
+              mask-size:1.6rem 1.6rem;
+      background-color:#78B4E8;
+    }
+  }
+  @media screen and (max-width: 600px) {
+    .usa-banner__header-text {
+      font-size: 1.4rem;
+    }
+    .usa-banner__header-action {
+      font-size: 1.4rem;
+    }
+    .usa-banner__button[aria-expanded=true]::before {
+      background-color: #e6e6e6;
+      height: 4.8rem;
+      width: 4.8rem;
+    }
+    .usa-banner__button[aria-expanded=true]::after {
+      height: 4.8rem;
+      width: 4.8rem;
+    }
+    @supports ((-webkit-mask: url("")) or (mask: url(""))) {
+      .usa-banner__button::after {
+        -webkit-mask-size: 2.4rem 2.4rem;
+        mask-size: 2.4rem 2.4rem;
+      }
+      .usa-banner__button[aria-expanded=true]::after {
+        -webkit-mask-size: 2.4rem 2.4rem;
+        mask-size: 2.4rem 2.4em;
+      }
+    }
   }
   .usa-banner__button::after {
     background-color: #78B4E8;
   }
   .usa-banner__button[aria-expanded=true]::before {
-    background-color: #00264C;
+    background-color: transparent; /* #00264C;*/
   }
   .usa-banner__button[aria-expanded=true]::after {
     background-color: #78B4E8;
@@ -156,6 +221,9 @@
   .usa-banner__content {
     font-size: 1.6rem;
     max-width: 100rem;
+  }
+  .usa-banner__content p {
+    font-size: 1.6rem;
   }
   .usa-banner__icon {
     width: 4rem;


### PR DESCRIPTION

### Description
This fixes some styling bugs in the USWDS banner. These bugs stem from us using a different root font size, as they are tied to things sized with `rem` units. In future I plan to explore using a standard approach for root font size, as it would facilitate using USWDS component and other external components that use `rem` styling. But for our existing sites, this is the band-aid that makes sense.

I also updated the path for the metacard image, since that was broken

### Changes Made
* Correct sizing of svg images in banner (up and down chevrons)
* Fix font sizing and button display on mobile
* Update path for metacard image

Previously:

<img width="375" alt="image" src="https://github.com/user-attachments/assets/1dd84dde-1f25-4a31-b5a8-4b66b4753d62" />

Now:

<img width="404" alt="image" src="https://github.com/user-attachments/assets/410a2dac-a4c3-47d4-9fb0-5b062ab1dfb6" />

Previously:

<img width="278" alt="image" src="https://github.com/user-attachments/assets/d8a65d2e-d752-4e93-94f6-fe43561f7cee" />

Now:

<img width="278" alt="image" src="https://github.com/user-attachments/assets/dcc1574d-db53-4a28-aba1-eb3bddf424bd" />

### How to Test
Pull changes locally, modify lines 3 and 4 of `src/App.vue` like so:

```
    <WindowSize v-if="typeOfEnv !== '-test build-'" />
    <HeaderUSWDSBanner v-if="typeOfEnv === '-test build-'" />
```

then run `npm run dev` and confirm that the chevron is vertically centered with 'Here's how we know' and that on mobile, font sizing is consistent between 'An official website of the United State Government' and 'Here's how you know'.


### MR t-shirt size
- [x] extra-small (e.g., update color scheme)
- [ ] small (e.g., add tooltip to chart)
- [ ] medium (e.g., add new static chart, add new pipeline output)
- [ ] large (e.g., initial data processing pipeline, interactive chart)

### Timeline for review
- [ ] ASAP - blocker for deployment
- [ ] Today - blocker for ongoing work
- [ ] Next couple of days
- [x] This week
- [ ] When reviewer has availability

### Review Needs
Does this MR include data processing, modeling, or visualization code that will require domain review prior to release?
- [ ] Yes, and I have opened an issue to document the need for review, using the `DomainReview` issue template
- [ ] Yes, and a domain review issue already exists
- [x] No

### Related Issues
NA

### Additional Notes
NA

### Merge Request Checklists
- [x] Code changes adhere to best practices documented in `README.md`
- [x] Code has been cleaned the way Vue likes it - run `npm run lint`
- [ ] If applicable, the need for future domain review has been documented in an issue
- [x] Below section documents which browsers the site has been tested on:
  - Desktop/laptop
    - [ ] Chrome
    - [ ] Safari
    - [x] Edge
    - [ ] Firefox
  - Mobile device
    - [ ] Chrome
    - [ ] Safari
    - [ ] Edge
    - [ ] Firefox
